### PR TITLE
Change main project author to “the rss2email maintainers” and drop maintainer list in setup.py

### DIFF
--- a/.update-copyright.conf
+++ b/.update-copyright.conf
@@ -10,6 +10,8 @@ ignored: AUTHORS | COPYING | README | README.rst | .update-copyright.conf |
 
 [aliases]
 Aaron Swartz: Aaron Swartz <me@aaronsw.com>
+Jeff Backus <jeff@jsbackus.com>: Jeff Backus <jeff.backus@gmail.com>
+Yannik Sembritzki <yannik@sembritzki.me>: Yannik <yannik@sembritzki.me>
 
 [author-hacks]
 rss2email/config.py: Aaron Swartz |

--- a/AUTHORS
+++ b/AUTHORS
@@ -17,3 +17,4 @@ Martin 'Joey' Schulze
 Matej Cepl
 Thiago Coutinho <root@thiagoc.net>
 W. Trevor King <wking@tremily.us>
+Profpatsch

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,20 +1,34 @@
 rss2email was written by:
 Aaron Swartz
+Adam Mokhtari <2553423+uutari@users.noreply.github.com>
+Andrey Zelenchuk <azelenchuk@parallels.com>
 Arun Persaud <apersaud@lbl.gov>
 Brian Lalor
 Dean Jackson
 Dennis Keitzel <github@pinshot.net>
 Dmitry Bogatov <KAction@gnu.org>
+Doron Behar <doron.behar@gmail.com>
 Eelis van der Weegen <eelis@eelis.net>
 Erik Hetzner
 Etienne Millon <me@emillon.org>
+François Boulogne <fboulogne sciunto org>
 George Saunders <georgesaunders@gmail.com>
 J. Lewis Muir <jlmuir@imca-cat.org>
+Jakub Wilk <jwilk@jwilk.net>
+Jeff Backus <jeff@jsbackus.com>
 Joey Hess
+Kh4l3tH <werther.b@gmail.com>
 Lindsey Smith <lindsey.smith@gmail.com>
 Marcel Ackermann
+Markus Unterwaditzer <markus@unterwaditzer.net>
 Martin 'Joey' Schulze
 Matej Cepl
+Mátyás Jani <jzombi@gmail.com>
+Profpatsch <mail@profpatsch.de>
+Puneeth Chaganti <punchagan@muse-amuse.in>
+Raphaël Droz <raphael.droz+floss@gmail.com>
+Simon Rozet <me@simonrozet.com>
 Thiago Coutinho <root@thiagoc.net>
+Thibaut Girka <thib@sitedethib.com>
 W. Trevor King <wking@tremily.us>
-Profpatsch
+Yannik Sembritzki <yannik@sembritzki.me>

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ v3.10 (unreleased)
     * Add a redirect post-process module.
     * Add new `feed-name` and `feed-url` attributes for the `name-format` setting.
     * Drop support for Python 3.2 and 3.3
+    * Remove `__contributors__` from the `rss2email` module.
 
 v3.9 (2014-09-01)
     * Catch and error out if a user adds a feed with a duplicate name.

--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,6 @@
+This file is a big TODO
+
+# Cutting a new release
+
+- TODO
+- run update-copyright.py

--- a/r2e.1
+++ b/r2e.1
@@ -305,7 +305,7 @@ first matching file is used.
 .B 
 .SH AUTHORS
 rss2email was started by Aaron Swartz, and is currently maintained by
-W. Trevor King.  For a more complete list of contributors, see the
-__contributors__ list in rss2email/__init__\&.py.
+a group of people.  For a more complete list of contributors, see the
+AUTHORS file in the rss2email distribution.
 .SH "REPORTING BUGS"
 Report bugs to the mailing list (see the README for details).

--- a/rss2email/__init__.py
+++ b/rss2email/__init__.py
@@ -1,4 +1,7 @@
-# Copyright (C) 2012-2014 W. Trevor King <wking@tremily.us>
+# Copyright (C) 2012-2018 Adam Mokhtari <2553423+uutari@users.noreply.github.com>
+#                         François Boulogne <fboulogne sciunto org>
+#                         Profpatsch <mail@profpatsch.de>
+#                         W. Trevor King <wking@tremily.us>
 #
 # This file is part of rss2email.
 #

--- a/rss2email/__init__.py
+++ b/rss2email/__init__.py
@@ -23,7 +23,7 @@ import sys as _sys
 
 __version__ = '3.9'
 __url__ = 'https://github.com/rss2email/rss2email'
-__author__ = 'W. Trevor King'
+__author__ = 'The rss2email maintainers'
 __email__ = 'rss2email@tremily.us'
 __copyright__ = '(C) 2004 Aaron Swartz. GNU GPL 2 or 3.'
 __contributors__ = [
@@ -39,7 +39,8 @@ __contributors__ = [
     'Marcel Ackermann (http://www.DreamFlasher.de)',
     "Martin 'Joey' Schulze",
     'Matej Cepl',
-    'W. Trevor King',
+    'W. Trevor King (long-time maintainer)',
+    'Profpatsch',
     ]
 
 LOG = _logging.getLogger('rss2email')

--- a/rss2email/__init__.py
+++ b/rss2email/__init__.py
@@ -26,22 +26,6 @@ __url__ = 'https://github.com/rss2email/rss2email'
 __author__ = 'The rss2email maintainers'
 __email__ = 'rss2email@tremily.us'
 __copyright__ = '(C) 2004 Aaron Swartz. GNU GPL 2 or 3.'
-__contributors__ = [
-    'Aaron Swartz (original author)',
-    'Brian Lalor',
-    'Dean Jackson',
-    'Eelis van der Weegen',
-    'Erik Hetzner',
-    'Etienne Millon',
-    'George Saunders',
-    'Joey Hess',
-    'Lindsey Smith (lindsey@allthingsrss.com)',
-    'Marcel Ackermann (http://www.DreamFlasher.de)',
-    "Martin 'Joey' Schulze",
-    'Matej Cepl',
-    'W. Trevor King (long-time maintainer)',
-    'Profpatsch',
-    ]
 
 LOG = _logging.getLogger('rss2email')
 LOG.addHandler(_logging.StreamHandler())

--- a/rss2email/command.py
+++ b/rss2email/command.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2012-2014 W. Trevor King <wking@tremily.us>
+# Copyright (C) 2012-2015 Etienne Millon <me@emillon.org>
+#                         W. Trevor King <wking@tremily.us>
 #
 # This file is part of rss2email.
 #

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -1,17 +1,22 @@
-# Copyright (C) 2004-2014 Aaron Swartz
+# Copyright (C) 2004-2017 Aaron Swartz
+#                         Andrey Zelenchuk <azelenchuk@parallels.com>
 #                         Brian Lalor
 #                         Dean Jackson
 #                         Dmitry Bogatov <KAction@gnu.org>
 #                         Erik Hetzner
 #                         Etienne Millon <me@emillon.org>
+#                         François Boulogne <fboulogne sciunto org>
 #                         George Saunders <georgesaunders@gmail.com>
+#                         Jakub Wilk <jwilk@jwilk.net>
 #                         Joey Hess
 #                         Lindsey Smith <lindsey.smith@gmail.com>
 #                         Marcel Ackermann
 #                         Martin 'Joey' Schulze
 #                         Matej Cepl
 #                         Thiago Coutinho <root@thiagoc.net>
+#                         Thibaut Girka <thib@sitedethib.com>
 #                         W. Trevor King <wking@tremily.us>
+#                         Yannik Sembritzki <yannik@sembritzki.me>
 #
 # This file is part of rss2email.
 #

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -1,10 +1,14 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright (C) 2012-2014 Arun Persaud <apersaud@lbl.gov>
+# Copyright (C) 2012-2017 Arun Persaud <apersaud@lbl.gov>
 #                         Dmitry Bogatov <KAction@gnu.org>
 #                         George Saunders <georgesaunders@gmail.com>
+#                         Jeff Backus <jeff@jsbackus.com>
+#                         Mátyás Jani <jzombi@gmail.com>
 #                         Thiago Coutinho <root@thiagoc.net>
+#                         Thibaut Girka <thib@sitedethib.com>
 #                         W. Trevor King <wking@tremily.us>
+#                         Yannik Sembritzki <yannik@sembritzki.me>
 #
 # This file is part of rss2email.
 #

--- a/rss2email/error.py
+++ b/rss2email/error.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2012-2014 W. Trevor King <wking@tremily.us>
+# Copyright (C) 2012-2015 Etienne Millon <me@emillon.org>
+#                         W. Trevor King <wking@tremily.us>
 #
 # This file is part of rss2email.
 #

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2004-2014 Aaron Swartz
+# Copyright (C) 2004-2017 Aaron Swartz
+#                         Andrey Zelenchuk <azelenchuk@parallels.com>
 #                         Brian Lalor
 #                         Dean Jackson
 #                         Dennis Keitzel <github@pinshot.net>
@@ -7,6 +8,7 @@
 #                         Etienne Millon <me@emillon.org>
 #                         George Saunders <georgesaunders@gmail.com>
 #                         J. Lewis Muir <jlmuir@imca-cat.org>
+#                         Jakub Wilk <jwilk@jwilk.net>
 #                         Joey Hess
 #                         Lindsey Smith <lindsey.smith@gmail.com>
 #                         Marcel Ackermann

--- a/rss2email/feeds.py
+++ b/rss2email/feeds.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2004-2014 Aaron Swartz
+# Copyright (C) 2004-2017 Aaron Swartz
+#                         Andrey Zelenchuk <azelenchuk@parallels.com>
 #                         Brian Lalor
 #                         Dean Jackson
 #                         Erik Hetzner
@@ -8,6 +9,7 @@
 #                         Marcel Ackermann
 #                         Martin 'Joey' Schulze
 #                         Matej Cepl
+#                         Raphaël Droz <raphael.droz+floss@gmail.com>
 #                         W. Trevor King <wking@tremily.us>
 #
 # This file is part of rss2email.

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2012-2013 W. Trevor King <wking@tremily.us>
+# Copyright (C) 2012-2017 Andrey Zelenchuk <azelenchuk@parallels.com>
+#                         W. Trevor King <wking@tremily.us>
 #
 # This file is part of rss2email.
 #

--- a/rss2email/post_process/prettify.py
+++ b/rss2email/post_process/prettify.py
@@ -1,5 +1,6 @@
-# Copyright (C) 2013 Arun Persaud <apersaud@lbl.gov>
-#                    W. Trevor King <wking@tremily.us>
+# Copyright (C) 2013-2015 Arun Persaud <apersaud@lbl.gov>
+#                         Etienne Millon <me@emillon.org>
+#                         W. Trevor King <wking@tremily.us>
 #
 # This file is part of rss2email.
 #

--- a/rss2email/post_process/redirect.py
+++ b/rss2email/post_process/redirect.py
@@ -1,4 +1,8 @@
-# Copyright (C) 2013 Francois Boulogne <fboulogne at april dot org>
+# Copyright (C) 2013-2017 Andrey Zelenchuk <azelenchuk@parallels.com>
+#                         François Boulogne <fboulogne sciunto org>
+#                         Jakub Wilk <jwilk@jwilk.net>
+#                         Puneeth Chaganti <punchagan@muse-amuse.in>
+#                         W. Trevor King <wking@tremily.us>
 #
 # This file is part of rss2email.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
-# Copyright (C) 2012-2013 Arun Persaud <apersaud@lbl.gov>
+# Copyright (C) 2012-2018 Adam Mokhtari <2553423+uutari@users.noreply.github.com>
+#                         Arun Persaud <apersaud@lbl.gov>
+#                         Markus Unterwaditzer <markus@unterwaditzer.net>
 #                         W. Trevor King <wking@tremily.us>
 #
 # This file is part of rss2email.


### PR DESCRIPTION
Seems fitting if we move to a community-maintained project.