### PR TITLE
Feed id may be present but is empty

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -457,6 +457,9 @@ class Feed (object):
         guid = entry.get('id', id_)
         if isinstance(guid, dict):
             guid = guid.values()[0]
+        # In some bad RSS feeds, id is present but empty...
+        if guid == '':
+            guid = id_
         if guid in self.seen:
             if self.seen[guid]['id'] == id_:
                 _LOG.debug('already seen {}'.format(id_))


### PR DESCRIPTION
Sometimes, id is present after feed parsing but remains empty, leading to empty history on saving.
So we fetch all feeds again and again when there is a new one.