### PR TITLE
Fix inconsistency bug introduced in b0398b6bf2309ab6

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -214,12 +214,12 @@ class Feed (object):
                 (attr, getattr(self, attr))
                 for attr in self._dynamic_attributes))
         self.load_from_config(config=config)
-        if from_email:
-            self.from_email = from_email
         if url:
             self.url = url
         if to:
             self.to = to
+        if from_email:
+            self.from_email = from_email
 
     def __str__(self):
         if self.force_from and\

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -89,7 +89,7 @@ def run(*args, **kwargs):
         'email', nargs='?',
         help='target email for the new feed')
     add_parser.add_argument(
-        'from-email', nargs='?',
+        '--from-email', dest='from_email',
         help='override from field in sent email')
 
     run_parser = subparsers.add_parser(


### PR DESCRIPTION
Fix inconsistency bug introduced in b0398b6bf2309ab65125566a8ee7167c840dcbcc : args set variable "from-email" and not "from_email" leading to undefined variable during feed creation.

Now --from-email is an optional argument and does not affects positional argument parsing.