### PR TITLE
Add a way to override user configured FROM field in add command

### DIFF
--- a/rss2email/command.py
+++ b/rss2email/command.py
@@ -48,7 +48,7 @@ def email(feeds, args):
 
 def add(feeds, args):
     "Add a new feed to the database"
-    feed = feeds.new_feed(name=args.name, url=args.url, to=args.email)
+    feed = feeds.new_feed(name=args.name, url=args.url, to=args.email, from_email=args.from_email)
     _LOG.info('add new feed {}'.format(feed))
     if not feed.to:
         raise _error.NoToEmailAddress(feed=feed, feeds=feeds)

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -207,7 +207,7 @@ class Feed (object):
         'digest_post_process',
         ]
 
-    def __init__(self, name=None, url=None, to=None, config=None):
+    def __init__(self, name=None, url=None, to=None, from_email=None, config=None):
         self._set_name(name=name)
         self.reset()
         self.__setstate__(dict(
@@ -218,9 +218,15 @@ class Feed (object):
             self.url = url
         if to:
             self.to = to
+        if from_email:
+            self.from_email = from_email
 
     def __str__(self):
-        return '{} ({} -> {})'.format(self.name, self.url, self.to)
+        if self.force_from and\
+           self.from_email != self.config['DEFAULT']['from']:
+            return '{} ({} -> {} (from {}))'.format(self.name, self.url, self.to, self.from_email)
+        else:
+            return '{} ({} -> {})'.format(self.name, self.url, self.to)
 
     def __repr__(self):
         return '<Feed {}>'.format(str(self))
@@ -319,6 +325,7 @@ class Feed (object):
         self.etag = None
         self.modified = None
         self.seen = {}
+        self.from_email = None
 
     def _set_name(self, name):
         if not self._name_regexp.match(name):

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -88,6 +88,9 @@ def run(*args, **kwargs):
     add_parser.add_argument(
         'email', nargs='?',
         help='target email for the new feed')
+    add_parser.add_argument(
+        '--from-email', dest='from_email',
+        help='override from field in sent email')
 
     run_parser = subparsers.add_parser(
         'run', help=_command.run.__doc__.splitlines()[0])


### PR DESCRIPTION
Add an optional --from-email argument to "add" command.
In combination with force_from configuration, this allows to override FROM sender email for a specific feed.
It's usefull to automatically classify feeds.