### PR TITLE
update reference to README.rst in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
     platforms=['all'],
     description=__doc__,
     long_description=_codecs.open(
-        _os_path.join(_this_dir, 'README'), 'r', encoding='utf-8').read(),
+        _os_path.join(_this_dir, 'README.rst'), 'r', encoding='utf-8').read(),
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Environment :: Console',


### PR DESCRIPTION
851d9835fb73632717c97d03b7655a0039527ba4 renamed README to README.rst but
didn't update setup.py to point to the new name.