### PR TITLE
Use lockf so locking data file works on NFS (fixes #10)

### DIFF
--- a/rss2email/feeds.py
+++ b/rss2email/feeds.py
@@ -266,8 +266,8 @@ class Feeds (list):
 
         locktype = 0
         if lock and UNIX:
-            locktype = _fcntl.LOCK_EX
-            _fcntl.flock(self._datafile_lock.fileno(), locktype)
+            locktype = _fcntl.LOCK_SH
+            _fcntl.lockf(self._datafile_lock.fileno(), locktype)
 
         self.clear()
 


### PR DESCRIPTION
If your home is on NFS (as mine is), you get this error when we try to lock the data file:

```
Traceback (most recent call last):
  File "/home/kaashif/.local/bin/r2e", line 5, in <module>
    rss2email.main.run()
  File "/home/kaashif/.local/lib/python3.6/site-packages/rss2email/main.py", line 168, in run
    feeds.load(lock=lock)
  File "/home/kaashif/.local/lib/python3.6/site-packages/rss2email/feeds.py", line 247, in load
    self._load_feeds(lock=lock, require=require)
  File "/home/kaashif/.local/lib/python3.6/site-packages/rss2email/feeds.py", line 270, in _load_feeds
    _fcntl.flock(self._datafile_lock.fileno(), locktype)
OSError: [Errno 9] Bad file descriptor
```

This is because Python's `fcntl.flock` uses the `flock` syscall, which doesn't work on NFS. We can instead use Python `fcntl.lockf`, which uses the `fcntl` syscall, which does work over NFS. Despite the name, `lockf` in Python does not use the `lockf` C function. We can't use a `LOCK_EX` lock any more, since exclusively locking a file open only for reading (not writing) fails with a "bad file descriptor" error. We don't need an exclusive lock anyway since the file is open for reading only, a shared lock is fine.