### PR TITLE
Add sleep interval between fetches from same server (closes #53)

### DIFF
--- a/rss2email/command.py
+++ b/rss2email/command.py
@@ -62,7 +62,7 @@ def run(feeds, args):
     try:
         # How long (in seconds) to sleep between running feeds with
         # the same server.
-        interval = int(feeds.config['DEFAULT']['same-server-fetch-interval'])
+        interval = float(feeds.config['DEFAULT']['same-server-fetch-interval'])
 
         # We use the domain name to determine if we are fetching from
         # the same server twice in a row.

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -92,6 +92,8 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ('proxy', ''),
         # Set the timeout (in seconds) for feed server response
         ('feed-timeout', str(60)),
+        # Set the time (in seconds) to sleep between fetches from the same server
+        ('same-server-fetch-interval', str(0)),
 
         ### Processing
         # True: Fetch, process, and email feeds.

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -194,6 +194,7 @@ class Feed (object):
 
     _integer_attributes = [
         'feed_timeout',
+        'same-server-fetch-interval',
         'body_width',
         ]
 

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -194,7 +194,6 @@ class Feed (object):
 
     _integer_attributes = [
         'feed_timeout',
-        'same-server-fetch-interval',
         'body_width',
         ]
 


### PR DESCRIPTION
This adds the `same-server-fetch-interval` config key, which lets the user specify a sleep interval between consecutive fetches from the same server. This would fix the problem described in #53. I think it is generally a good idea to avoid being an obnoxious client, and this contributes to that.

I'm not convinced I added the config key correctly, I think someone should look this over - I have only a vague understanding of the code. I have tested it and it seems to work though.