### PR TITLE
Add -s/--set command line option to set config keys on the command line

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 UNRELEASED
     * Add new `user-agent` attribute for configuring email User-Agent
+    * Add `--set` command line option for overriding the configuration
 
 v3.10 (2019-09-01)
     * Catch and warn for invalid Content-Types

--- a/r2e.1
+++ b/r2e.1
@@ -49,6 +49,23 @@ Dynamic program data is read from $XDG_DATA_HOME/rss2mail\&.json by
 default (see also FILES and ENVIRONMENT VARIABLES below).  Use this
 option to set a different data file.
 .TP
+\-s, \-\-set \fI<key>\fR \fI<value>\fR
+Set the config key \fI<key>\fR to \fI<value>\fR for the duration of
+the current invocation. See CONFIGURATION for possible keys and
+values. Note: if \-s is used when adding a new feed, for example to
+override the 'from' address, this is the only case where the new
+config is written to disk. For example:
+
+.RS 8
+.EX
+$ r2e -s from override@example.com add eff https://www.eff.org/rss/updates.xml
+$ tail -3 $XDG_CONFIG_HOME/rss2email.cfg
+[feed.eff]
+url = https://www.eff.org/rss/updates.xml
+from = override@example.com
+.EE
+.RE
+.TP
 \-V, \-\-verbose
 Increment the logging verbosity.
 .SH COMMANDS

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -108,6 +108,10 @@ class Config (_configparser.ConfigParser):
             for section in new_sections:
                 # Create the sections with the overrides
                 disk_config[section] = dict(self[section])
+
+            # Change the default target email if we have changed it
+            # (this only happens through 'r2e email')
+            disk_config['DEFAULT']['to'] = self['DEFAULT'].real_section['to']
             disk_config.write(f)
         else:
             # Else we are creating the on-disk config for the first

--- a/rss2email/feeds.py
+++ b/rss2email/feeds.py
@@ -130,7 +130,7 @@ class Feeds (list):
     datafile_version = 2
     datafile_encoding = 'utf-8'
 
-    def __init__(self, configfiles=None, datafile=None, config=None):
+    def __init__(self, configfiles=None, datafile=None, config=None, config_overrides={}):
         super(Feeds, self).__init__()
         if configfiles is None:
             configfiles = self._get_configfiles()
@@ -141,6 +141,7 @@ class Feeds (list):
         if config is None:
             config = _config.CONFIG
         self.config = config
+        self.config.set_overrides(config_overrides)
         self._datafile_lock = None
 
     def __getitem__(self, key):

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -62,6 +62,9 @@ def run(*args, **kwargs):
     parser.add_argument(
         '-V', '--verbose', default=0, action='count',
         help='increment verbosity')
+    parser.add_argument(
+        '-s', '--set', action='append', nargs=2, metavar=('key', 'value'),
+        help='override config key to value')
     subparsers = parser.add_subparsers(title='commands')
 
     new_parser = subparsers.add_parser(
@@ -151,6 +154,10 @@ def run(*args, **kwargs):
     if args.verbose:
         _LOG.setLevel(max(_logging.DEBUG, _logging.ERROR - 10 * args.verbose))
 
+    config_overrides = {}
+    if args.set:
+        config_overrides = {key:value for [key, value] in args.set}
+
     # https://docs.python.org/3/library/logging.html#logrecord-attributes
     formatter = _logging.Formatter('%(asctime)s [%(levelname)s] %(message)s')
     for handler in _LOG.handlers: # type: _logging.Handler
@@ -162,7 +169,9 @@ def run(*args, **kwargs):
     try:
         if not args.config:
             args.config = None
-        feeds = _feeds.Feeds(datafile=args.data, configfiles=args.config)
+        feeds = _feeds.Feeds(datafile=args.data,
+                             configfiles=args.config,
+                             config_overrides=config_overrides)
         if args.func != _command.new:
             lock = args.func not in [_command.list, _command.opmlexport]
             feeds.load(lock=lock)


### PR DESCRIPTION
This is an implementation of the more general config overriding @Ekleog mentioned in the comments on #44 .

The behaviour is that if you override a key on the command line, it is only overridden for the duration of that invocation - your overriden value is *not* added to the config file. This is reasonable behaviour and mirrors what git does, for example.

The exception is when the in-memory config has a section added to it e.g. when you are adding a new feed (actually I think this is the only time that happens). Then, the overrides *are* written to disk in the new section. This means the user can do things like overriding the "to" address for a feed when adding it, by invoking:

```
$ r2e -s to kaashif@example.com add eff https://eff.org/rss/updates.xml
```

And this "to" address will be written to disk in the config file. In all other cases we are not adding a new section to the config, so the config overrides do not persist.

In terms of the implementation, I think I've done it in the way that involves the fewest changes to the source code. Yes it does involve a global variable in `config.py` but I think this is the easiest way to make sure the overrides are consistently used everywhere even if the config is re-read from disk and we have a new Feeds object. I'm not sure whether this happens anywhere though, maybe a cleaner design would also work.

Comments on the design, naming, implementation etc are welcome.