### PR TITLE
improve logging

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -396,7 +396,7 @@ class Feed (object):
         if version:
             _LOG.debug('feed version {}'.format(version))
         else:
-            _LOG.warning('unrecognized version: {}'.format(self))
+            _LOG.debug('unrecognized version: {}'.format(self))
             warned = True
 
         exc = parsed.get('bozo_exception', None)


### PR DESCRIPTION
60% of feeds don't have a version tag and that's no problem at all.

no need to produce a warning.