### PR TITLE
Update changelog for v3.10

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,7 +12,10 @@ v3.10 (unreleased)
     * Fix SMTP security issues
     * Fix test suite
     * Drop support for Python 3.2 and 3.3
-    * Remove `__contributors__` from the `rss2email` module.
+    * Remove `__contributors__` from the `rss2email` module
+    * Stop using deprecated `html2text.unescape`
+    * Fix locking issues when data file is on NFS
+    * Add `same-server-fetch-interval` setting for rate-limiting fetches to a server
 
 v3.9 (2014-09-01)
     * Catch and error out if a user adds a feed with a duplicate name


### PR DESCRIPTION
I think these are the last significant things that need to be added to the changelog.

I think 3.10 is ready for release now, someone with the rights should make a release on GitHub and PyPI after the changelog is updated. I could do it on GitHub but I'm not a maintainer on PyPI so I can't do it there.

Let me know if anything is missing.