### PR TITLE
Allow configuration of User-Agent string

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,7 @@
 rss2email was written by:
 Aaron Swartz
 Adam Mokhtari <2553423+uutari@users.noreply.github.com>
+Anders Damsgaard <anders@adamsgaard.dk>
 Andrey Zelenchuk <azelenchuk@parallels.com>
 Arun Persaud <apersaud@lbl.gov>
 Brian Lalor

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+UNRELEASED
+    * Add new `user-agent` attribute for configuring email User-Agent
+
 v3.10 (2019-09-01)
     * Catch and warn for invalid Content-Types
     * Add a manually extracted list of config options to r2e.1

--- a/r2e.1
+++ b/r2e.1
@@ -237,6 +237,9 @@ Wrap long lines at position. 0 for no wrapping.
 Select protocol from: sendmail, smtp, imap, maildir
 .IP sendmail
 Path to sendmail (or compatible)
+.IP user-agent
+String to use as User-Agent in outgoing emails. If present, __VERSION__ and
+__URL__ are replaced with rss2email version number and webpage
 .RE
 .SS SMTP configuration
 .IP smtp-auth

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -40,8 +40,6 @@ import configparser as _configparser
 
 import html2text as _html2text
 
-from . import __url__
-
 class Config (_configparser.ConfigParser):
     def __init__(self, dict_type=_collections.OrderedDict,
                  interpolation=_configparser.ExtendedInterpolation(),
@@ -71,8 +69,8 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ### Addressing
         # The email address messages are from by default
         ('from', 'user@rss2email.invalid'),
-        # The User-Agent default string (__VERSION__ is replaced)
-        ('user-agent', 'rss2email/__VERSION__ ({})'.format(__url__)),
+        # The User-Agent default string (rss2email __VERSION__ and __URL__ is replaced)
+        ('user-agent', 'rss2email/__VERSION__ (__URL__)'),
         # Transfer-Encoding. For local mailing it is safe and
         # convenient to use 8bit.
         ('use-8bit', str(False)),

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -40,6 +40,9 @@ import configparser as _configparser
 
 import html2text as _html2text
 
+from . import __url__
+from . import __version__
+
 
 class Config (_configparser.ConfigParser):
     def __init__(self, dict_type=_collections.OrderedDict,
@@ -70,6 +73,8 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ### Addressing
         # The email address messages are from by default
         ('from', 'user@rss2email.invalid'),
+        # The User-Agent default string
+        ('user-agent', 'rss2email/{} ({})'.format(__version__, __url__)),
         # Transfer-Encoding. For local mailing it is safe and
         # convenient to use 8bit.
         ('use-8bit', str(False)),

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -42,7 +42,6 @@ import html2text as _html2text
 
 from . import __url__
 
-
 class Config (_configparser.ConfigParser):
     def __init__(self, dict_type=_collections.OrderedDict,
                  interpolation=_configparser.ExtendedInterpolation(),

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -71,8 +71,8 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ### Addressing
         # The email address messages are from by default
         ('from', 'user@rss2email.invalid'),
-        # The User-Agent default string (_VERSION_ is replaced)
-        ('user-agent', 'rss2email/_VERSION_ ({})'.format(__url__)),
+        # The User-Agent default string (__VERSION__ is replaced)
+        ('user-agent', 'rss2email/__VERSION__ ({})'.format(__url__)),
         # Transfer-Encoding. For local mailing it is safe and
         # convenient to use 8bit.
         ('use-8bit', str(False)),

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -41,7 +41,6 @@ import configparser as _configparser
 import html2text as _html2text
 
 from . import __url__
-from . import __version__
 
 
 class Config (_configparser.ConfigParser):
@@ -73,8 +72,8 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ### Addressing
         # The email address messages are from by default
         ('from', 'user@rss2email.invalid'),
-        # The User-Agent default string
-        ('user-agent', 'rss2email/{} ({})'.format(__version__, __url__)),
+        # The User-Agent default string (_VERSION_ is replaced)
+        ('user-agent', 'rss2email/_VERSION_ ({})'.format(__url__)),
         # Transfer-Encoding. For local mailing it is safe and
         # convenient to use 8bit.
         ('use-8bit', str(False)),

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -61,8 +61,6 @@ from . import error as _error
 from . import util as _util
 
 
-_USER_AGENT = 'rss2email/{} ({})'.format(__version__, __url__)
-_feedparser.USER_AGENT = _USER_AGENT
 _urllib_request.install_opener(_urllib_request.build_opener())
 _SOCKET_ERRORS = []
 for e in ['error', 'herror', 'gaierror']:
@@ -219,6 +217,7 @@ class Feed (object):
             self.url = url
         if to:
             self.to = to
+        self.user_agent = self.user_agent.replace('_VERSION_', __version__)
 
     def __str__(self):
         return '{} ({} -> {})'.format(self.name, self.url, self.to)
@@ -458,10 +457,11 @@ class Feed (object):
         _LOG.debug('not seen {}'.format(guid))
         sender = self._get_entry_email(parsed=parsed, entry=entry)
         subject = self._get_entry_title(entry)
+
         extra_headers = _collections.OrderedDict((
                 ('Date', self._get_entry_date(entry)),
                 ('Message-ID', '<{}@dev.null.invalid>'.format(_uuid.uuid4())),
-                ('User-Agent', _USER_AGENT),
+                ('User-Agent', self.user_agent),
                 ('X-RSS-Feed', self.url),
                 ('X-RSS-ID', guid),
                 ('X-RSS-URL', self._get_entry_link(entry)),
@@ -867,7 +867,7 @@ class Feed (object):
         digest['To'] = self.to  # TODO: _Header(), _formataddr((recipient_name, recipient_addr))
         digest['Subject'] = 'digest for {}'.format(self.name)
         digest['Message-ID'] = '<{}@dev.null.invalid>'.format(_uuid.uuid4())
-        digest['User-Agent'] = _USER_AGENT
+        digest['User-Agent'] = self.user_agent
         digest['X-RSS-Feed'] = self.url
         return digest
 

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -217,7 +217,7 @@ class Feed (object):
             self.url = url
         if to:
             self.to = to
-        self.user_agent = self.user_agent.replace('_VERSION_', __version__)
+        self.user_agent = self.user_agent.replace('__VERSION__', __version__)
 
     def __str__(self):
         return '{} ({} -> {})'.format(self.name, self.url, self.to)

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -218,6 +218,7 @@ class Feed (object):
         if to:
             self.to = to
         self.user_agent = self.user_agent.replace('__VERSION__', __version__)
+        self.user_agent = self.user_agent.replace('__URL__', __url__)
 
     def __str__(self):
         return '{} ({} -> {})'.format(self.name, self.url, self.to)

--- a/test/allthingsrss/4.config
+++ b/test/allthingsrss/4.config
@@ -1,0 +1,8 @@
+[DEFAULT]
+to = a@b.com
+date-header = True
+unicode-snob = True
+links-after-each-paragraph = True
+body-width = 70
+use-8bit = True
+user-agent = test string

--- a/test/allthingsrss/4.expected
+++ b/test/allthingsrss/4.expected
@@ -1,0 +1,104 @@
+SENT BY: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="us-ascii"
+From: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+To: a@b.com
+Subject: Version 2.67 Released
+Content-Transfer-Encoding: 7bit
+Date: Tue, 21 Sep 2010 16:55:07 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: test string
+X-RSS-Feed: allthingsrss/feed.atom
+X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=62
+X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/aGbf5Gefkmc/
+X-RSS-TAGS: Uncategorized
+
+Version 2.67 of rss2email is now available for both
+[Linux](http://www.allthingsrss.com/rss2email/rss2email-2.67.tar.gz) and
+[Windows](http://www.allthingsrss.com/rss2email/rss2email-2.67.zip), which
+includes the latest development version of feedparser. Changes from the
+previous version:
+
+  * Fixed entries that include an id which is blank (i.e., an empty string) were being resent
+  * Fixed some entries not being sent by email because they had bad From headers
+  * Fixed From headers with HTML entities encoded twice
+  * Compatibility changes to support most recent development versions of feedparser
+  * Compatibility changes to support Google Reader feeds
+
+Complete list in the official
+[CHANGELOG](http://www.allthingsrss.com/rss2email/changelog).
+
+[![](http://feedads.g.doubleclick.net/~a/Sjq8v-Lq2dNKzkelsypiC4fjPLM/0/di)](http://feedads.g.doubleclick.net/~a/Sjq8v-Lq2dNKzkelsypiC4fjPLM/0/da)  
+[![](http://feedads.g.doubleclick.net/~a/Sjq8v-Lq2dNKzkelsypiC4fjPLM/1/di)](http://feedads.g.doubleclick.net/~a/Sjq8v-Lq2dNKzkelsypiC4fjPLM/1/da)
+
+![](http://feeds.feedburner.com/~r/allthingsrss/hJBr/~4/aGbf5Gefkmc)
+
+
+
+URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/aGbf5Gefkmc/
+
+SENT BY: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="us-ascii"
+From: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+To: a@b.com
+Subject: Version 2.68 Released with Actual New Features
+Content-Transfer-Encoding: 7bit
+Date: Fri, 01 Oct 2010 18:21:26 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: test string
+X-RSS-Feed: allthingsrss/feed.atom
+X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=72
+X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/bT-I0iH2vw8/
+X-RSS-TAGS: Uncategorized
+
+Unlike the last few versions of rss2email that have trickled out, I finally
+got around to adding a few new oft-requested features! Version 2.68 of
+rss2email is now available for both
+[Linux](http://www.allthingsrss.com/rss2email/rss2email-2.68.tar.gz) and
+[Windows](http://www.allthingsrss.com/rss2email/rss2email-2.68.zip).
+
+Changes from the previous version:
+
+  * Added ability to pause/resume checking of individual feeds through pause and unpause commands
+  * Added ability to import and export OPML feed lists through importopml and exportopml commands
+
+Complete list in the official
+[CHANGELOG](http://www.allthingsrss.com/rss2email/changelog).
+
+**Pause/Unpause**
+
+Through `r2e pause _n_` where _n_ is a feed number, you can temporarily
+suspend checking that feed for new content. To start checking it again, simply
+run `r2e unpause _n_`. When you `r2e list`, an asterisk indicates that the
+feed is currently unpaused and active.
+
+[![](http://feedads.g.doubleclick.net/~a/nYgTsIUsS9pmvRZ6092XGGHnNKg/0/di)](http://feedads.g.doubleclick.net/~a/nYgTsIUsS9pmvRZ6092XGGHnNKg/0/da)  
+[![](http://feedads.g.doubleclick.net/~a/nYgTsIUsS9pmvRZ6092XGGHnNKg/1/di)](http://feedads.g.doubleclick.net/~a/nYgTsIUsS9pmvRZ6092XGGHnNKg/1/da)
+
+![](http://feeds.feedburner.com/~r/allthingsrss/hJBr/~4/bT-I0iH2vw8)
+
+
+
+URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/bT-I0iH2vw8/
+
+SENT BY: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="us-ascii"
+From: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+To: a@b.com
+Subject: How to Read RSS Feeds in Emacs
+Content-Transfer-Encoding: 7bit
+Date: Fri, 05 Nov 2010 17:36:14 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: test string
+X-RSS-Feed: allthingsrss/feed.atom
+X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=79
+X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/JryfOLe_q6c/
+X-RSS-TAGS: Uncategorized
+
+something something irrelevant
+
+
+
+URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/JryfOLe_q6c/


### PR DESCRIPTION
This PR adds the option to change the `User-Agent` string that is sent along with emails. I personally use `urlview` to filter the rss2email messages I receive, and wanted to avoid having the rss2email github link show up in every email. The new configuration parameter has the following default value:

    user-agent = rss2email/_VERSION_ (https://github.com/rss2email/rss2email)

The `_VERSION_` part is replaced with the appropriate version number, meaning that the **default behavior is unchanged**. I also added a test (`test/allthingsrss/4.{config,expected}`). Thanks for considering this PR.