### PR TITLE
Python 3.8 compatibility

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -22,8 +22,6 @@ let
     propagatedBuildInputs = with pkgSet.set; [
       feedparser
       html2text
-      # tests
-      beautifulsoup4
     ];
 
     doCheck = true;

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -6,6 +6,7 @@ let
     { version = "3_5"; set = pkgs.python35Packages; }
     { version = "3_6"; set = pkgs.python36Packages; }
     { version = "3_7"; set = pkgs.python37Packages; }
+    { version = "3_8"; set = pkgs.python38Packages; }
   ];
   latestSupportedPackageSet = pkgs.lib.last supportedPackageSets;
 

--- a/rss2email/util.py
+++ b/rss2email/util.py
@@ -18,8 +18,6 @@
 """
 
 import importlib as _importlib
-import pickle as _pickle
-import pickletools as _pickletools
 import sys as _sys
 import threading as _threading
 
@@ -82,34 +80,19 @@ def import_name(obj):
     """Return the full import name for a Python object
 
     Note that this does not always exist (e.g. for dynamically
-    generated functions).  This function does it's best, using Pickle
-    for the heavy lifting.  For example:
+    generated functions). A working example:
 
     >>> import_name(import_name)
     'rss2email.util import_name'
 
     Note the space between the module (``rss2email.util``) and the
     function within the module (``import_name``).
-
-    Some objects can't be pickled:
-
-    >>> import_name(lambda x: 'muahaha')
-    Traceback (most recent call last):
-      ...
-    _pickle.PicklingError: Can't pickle <class 'function'>: attribute lookup builtins.function failed
-
-    Some objects don't have a global scope:
-
-    >>> import_name('abc')
-    Traceback (most recent call last):
-      ...
-    ValueError: abc
     """
-    pickle = _pickle.dumps(obj)
-    for opcode,arg,pos in _pickletools.genops(pickle):
-        if opcode.name == 'GLOBAL':
-            return arg
-    raise ValueError(obj)
+    name = "{} {}".format(obj.__module__, obj.__qualname__)
+    if import_function(name) is obj:
+        return name
+    else:
+        raise ValueError(obj)
 
 def import_function(name):
     """Import a function using the full import name


### PR DESCRIPTION
### Issue description

When running r2e with Python 3.8 and specifying a post_process hook like `post-process = rss2email.post_process.prettify process`, the following exception occurs:

```
Traceback (most recent call last):
  File "/usr/local/bin/r2e", line 5, in <module>
    rss2email.main.run()
  File "/usr/local/lib/python3.8/site-packages/rss2email/main.py", line 169, in run
    args.func(feeds=feeds, args=args)
  File "/usr/local/lib/python3.8/site-packages/rss2email/command.py", line 85, in run
    feeds.save()
  File "/usr/local/lib/python3.8/site-packages/rss2email/feeds.py", line 346, in save
    feed.save_to_config()
  File "/usr/local/lib/python3.8/site-packages/rss2email/feed.py", line 254, in save_to_config
    value = self._get_configured_option_value(
  File "/usr/local/lib/python3.8/site-packages/rss2email/feed.py", line 301, in _get_configured_option_value
    return _util.import_name(value)
  File "/usr/local/lib/python3.8/site-packages/rss2email/util.py", line 113, in import_name
    raise ValueError(obj)
ValueError: <function call_hooks at 0x7f765cec2b80>
```


### Root cause

Python 3.8 apparently changed some internals regarding bytecode and opcodes, which in turn rendered the [`util.py#import_name(obj)`](https://github.com/rss2email/rss2email/blob/63f4a7d82f50e3a5657cf68c6e44ce5fde7745af/rss2email/util.py#L81) function to not work properly anymore.

For Python < 3.8 there was an opcode `GLOBAL` with the argument `"$module $function_name"` (`rss2email.post_process.prettify process` for example) which this function was trying to extract. In Python >= 3.8 however, during processing there is no opcode `GLOBAL` anymore. Hence the function defaults to a `ValueError`.

### Proposal 1 (_now obsolete)_

In my case the only appropriate opcode was `SHORT_BINUNICODE` with the argument `"$module"`. So I simply concat that with the original functions name.

I'm not sure this is the optimal way of handling this. My knowledge regarding these Python internals is limited.

### Proposal 2

Due to the root cause being a change in the default pickle protocol version, we just set the old version (3) explicitly.

### Some references

Here are some additional debug outputs of `opcode.name` and `arg` during processing. Python < 3.8:
```
opcode.name=PROTO; arg=3; pos=0
opcode.name=GLOBAL; arg=rss2email.post_process.prettify process; pos=2
# (The original function returned at this point)
```

And these are the opcodes for Python >= 3.8:
```
opcode.name='PROTO'; arg=4; pos=0
opcode.name='FRAME'; arg=47; pos=2
opcode.name='SHORT_BINUNICODE'; arg='rss2email.post_process.prettify'; pos=11
opcode.name='MEMOIZE'; arg=None; pos=41
opcode.name='SHORT_BINUNICODE'; arg='process'; pos=42
opcode.name='MEMOIZE'; arg=None; pos=54
opcode.name='STACK_GLOBAL'; arg=None; pos=55
opcode.name='MEMOIZE'; arg=None; pos=56
opcode.name='STOP'; arg=None; pos=57
# (The original function raised the value error above)
```
