### PR TITLE
Python 3.9 compatibility fixes.

### DIFF
--- a/rss2email/command.py
+++ b/rss2email/command.py
@@ -158,7 +158,7 @@ def opmlimport(feeds, args):
         raise _error.OPMLReadError() from e
     if args.file:
         f.close()
-    name_slug_regexp = _re.compile('[^\w\d.-]+')
+    name_slug_regexp = _re.compile(r'[^\w\d.-]+')
     for feed in new_feeds:
         if feed.hasAttribute('xmlUrl'):
             url = _saxutils.unescape(feed.getAttribute('xmlUrl'))

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -147,7 +147,7 @@ class Feed (object):
     >>> test_section = CONFIG.pop('feed.test-feed')
 
     """
-    _name_regexp = _re.compile('^[\w\d.-]+$')
+    _name_regexp = _re.compile(r'^[\w\d.-]+$')
 
     # saved/loaded from feed.dat using __getstate__/__setstate__.
     _dynamic_attributes = [

--- a/rss2email/util.py
+++ b/rss2email/util.py
@@ -72,7 +72,7 @@ class TimeLimitedFunction (_threading.Thread):
         if self.error:
             raise _error.TimeoutError(
                 time_limited_function=self) from self.error[1]
-        elif self.isAlive():
+        elif self.is_alive():
             raise _error.TimeoutError(time_limited_function=self)
         return self.result
 

--- a/test/test.py
+++ b/test/test.py
@@ -44,7 +44,7 @@ class TestEmails(unittest.TestCase):
         self.MESSAGE_ID_REGEXP = _re.compile(
             '^Message-ID: <[^@]*@dev.null.invalid>$', _re.MULTILINE)
         self.USER_AGENT_REGEXP = _re.compile(
-            '^User-Agent: rss2email/[0-9.]* (\S*)$', _re.MULTILINE)
+            r'^User-Agent: rss2email/[0-9.]* (\S*)$', _re.MULTILINE)
         self.BOUNDARY_REGEXP = _re.compile('===============[^=]+==')
 
     def clean_result(self, text):


### PR DESCRIPTION
* Fixes invalid escape sequences deprecation warning.
* Use threading.is_alive for Python 3.9 compatibility.

Fixes #85 