### PR TITLE
Lock the datafile at the start, only release at the end

### DIFF
--- a/nix/release.nix
+++ b/nix/release.nix
@@ -26,7 +26,9 @@ let
 
     doCheck = true;
     checkPhase = ''
-        python3 ./test/test.py --verbose
+      env \
+        R2E_PATH="$out/bin/r2e" \
+          python3 ./test/test.py --verbose
     '';
   };
 

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -26,10 +26,7 @@ let
 
     doCheck = true;
     checkPhase = ''
-      env \
-        PATH="$out/bin:$PATH" \
-        PYTHONPATH=.:"$PYTHONPATH" \
-          python3 ./test/test.py --verbose
+        python3 ./test/test.py --verbose
     '';
   };
 

--- a/rss2email/feeds.py
+++ b/rss2email/feeds.py
@@ -135,7 +135,7 @@ class Feeds (list):
         if config is None:
             config = _config.CONFIG
         self.config = config
-        self._datafile = None
+        self.datafile = None
 
     def __getitem__(self, key):
         for feed in self:
@@ -253,7 +253,7 @@ class Feeds (list):
             with _codecs.open(self.datafile_path, 'w', self.datafile_encoding) as f:
                 self._save_feed_states(feeds=[], stream=f)
         try:
-            self._datafile = _codecs.open(
+            self.datafile = _codecs.open(
                 self.datafile_path, 'r', self.datafile_encoding)
         except IOError as e:
             raise _error.DataFileError(feeds=self) from e
@@ -261,7 +261,7 @@ class Feeds (list):
         locktype = 0
         if lock:
             locktype = _fcntl.LOCK_SH
-            _fcntl.lockf(self._datafile.fileno(), locktype)
+            _fcntl.lockf(self.datafile.fileno(), locktype)
 
         self.clear()
 
@@ -269,10 +269,10 @@ class Feeds (list):
         handlers = list(_LOG.handlers)
         feeds = []
         try:
-            data = _json.load(self._datafile)
+            data = _json.load(self.datafile)
         except ValueError as e:
             _LOG.info('could not load data file using JSON')
-            data = self._load_pickled_data(self._datafile)
+            data = self._load_pickled_data(self.datafile)
         version = data.get('version', None)
         if version != self.datafile_version:
             data = self._upgrade_state_data(data)
@@ -290,8 +290,8 @@ class Feeds (list):
         self.extend(feeds)
 
         if locktype == 0:
-            self._datafile.close()
-            self._datafile = None
+            self.datafile.close()
+            self.datafile = None
 
         for feed in self:
             feed.load_from_config(self.config)
@@ -360,9 +360,9 @@ class Feeds (list):
             f.flush()
             _os.fsync(f.fileno())
         _os.replace(tmpfile, self.datafile_path)
-        if self._datafile is not None:
-            self._datafile.close()  # release the lock
-            self._datafile = None
+        if self.datafile is not None:
+            self.datafile.close()  # release the lock
+            self.datafile = None
 
     def _save_feed_states(self, feeds, stream):
         _json.dump(

--- a/rss2email/feeds.py
+++ b/rss2email/feeds.py
@@ -43,15 +43,7 @@ from . import config as _config
 from . import error as _error
 from . import feed as _feed
 
-UNIX = False
-try:
-    import fcntl as _fcntl
-    # A pox on SunOS file locking methods
-    if 'sunos' not in _sys.platform:
-        UNIX = True
-except:
-    pass
-
+import fcntl as _fcntl
 
 # Path to the filesystem root, '/' on POSIX.1 (IEEE Std 1003.1-2008).
 ROOT_PATH = _os.path.splitdrive(_sys.executable)[0] or _os.sep
@@ -267,7 +259,7 @@ class Feeds (list):
             raise _error.DataFileError(feeds=self) from e
 
         locktype = 0
-        if lock and UNIX:
+        if lock:
             locktype = _fcntl.LOCK_SH
             _fcntl.lockf(self._datafile.fileno(), locktype)
 
@@ -368,7 +360,7 @@ class Feeds (list):
             f.flush()
             _os.fsync(f.fileno())
         _os.replace(tmpfile, self.datafile_path)
-        if UNIX and self._datafile is not None:
+        if self._datafile is not None:
             self._datafile.close()  # release the lock
             self._datafile = None
 

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -175,8 +175,7 @@ def run(*args, **kwargs):
                 args.config = None
             feeds = _feeds.Feeds(datafile_path=args.data, configfiles=args.config)
             if args.func != _command.new:
-                lock = args.func not in [_command.list, _command.opmlexport]
-                feeds.load(lock=lock)
+                feeds.load()
             args.func(feeds=feeds, args=args)
     except _error.RSS2EmailError as e:
         e.log()

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -164,7 +164,7 @@ def run(*args, **kwargs):
     try:
         if not args.config:
             args.config = None
-        feeds = _feeds.Feeds(datafile=args.data, configfiles=args.config)
+        feeds = _feeds.Feeds(datafile_path=args.data, configfiles=args.config)
         if args.func != _command.new:
             lock = args.func not in [_command.list, _command.opmlexport]
             feeds.load(lock=lock)

--- a/test/README
+++ b/test/README
@@ -41,3 +41,9 @@ see exactly which tests are being run:
 
   $ ./test/test.py -v
 
+If you want to test an r2e script not in the repo (e.g. the system
+one), you can provide the environment variable R2E_PATH, with the
+absolute path to the script that you want to test. We use this in our
+CI build:
+
+  $ R2E_PATH=/path/to/your/r2e ./test/test.py -v

--- a/test/README
+++ b/test/README
@@ -1,6 +1,6 @@
 Run tests with::
 
-  $ env "PATH=$(pwd):$PATH" "PYTHONPATH=$(pwd):$PYTHONPATH" ./test/test.py
+  $ ./test/test.py
 
 … from the root of the project.
 
@@ -36,12 +36,8 @@ feed/config pair.  For example, with a directory structure like::
 * ``feed.rss`` after loading ``b.config`` and compare the output with
   ``b.expected``.
 
-If you only want to limit yourself to a subset of tests, you can
-specify subdirectories on the command line::
+Various other tests are also run, run test.py with the '-v' option to
+see exactly which tests are being run:
 
-  $ env "PATH=$(pwd):$PATH" "PYTHONPATH=$(pwd):$PYTHONPATH" ./test/test.py test/allthingsrss
+  $ ./test/test.py -v
 
-You can limit the tests even further by specify particular config
-files::
-
-  $ env "PATH=$(pwd):$PATH" "PYTHONPATH=$(pwd):$PYTHONPATH" ./test/test.py test/allthingsrss test/allthingsrss/1.config

--- a/test/test.py
+++ b/test/test.py
@@ -17,11 +17,13 @@ import http.server
 import time
 import sys
 
+# Directory containing test feed data/configs
+test_dir = _os.path.dirname(_os.path.abspath(__file__))
+
 # By default, we run the r2e in the dir above this script, not the
 # system-wide installed version, which you probably don't mean to
 # test.
-r2e_path = _os.path.join(_os.path.dirname(_os.path.abspath(__file__)),
-                         "..", "r2e")
+r2e_path = _os.path.join(test_dir, "..", "r2e")
 
 # Ensure we import the local (not system-wide) rss2email module
 sys.path.insert(0, _os.path.dirname(r2e_path))
@@ -168,7 +170,10 @@ class ExecContext:
         subprocess.call([r2e_path, "-c", self.cfg_path, "-d", self.data_path] + list(args))
 
 class NoLogHandler(http.server.SimpleHTTPRequestHandler):
-    "No-op handler for http.server"
+    "No logging handler serving test feed data"
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs, directory=test_dir)
+
     def log_message(self, format, *args):
         return
 

--- a/test/test.py
+++ b/test/test.py
@@ -173,8 +173,9 @@ class ExecContext:
         return self
 
     def __exit__(self, type, value, traceback):
-        _os.remove(self.cfg_path)
-        _os.remove(self.data_path)
+        for path in [self.cfg_path, self.data_path]:
+            if _os.path.exists(path):
+                _os.remove(path)
         _os.rmdir(self.tmpdir)
 
     def call(self, *args):

--- a/test/test.py
+++ b/test/test.py
@@ -38,20 +38,14 @@ class TestEmailsMeta(type):
     def __new__(cls, name, bases, attrs):
         # no paths on the command line, find all subdirectories
         this_dir = _os.path.dirname(__file__)
-        test_dirs = []
-        for basename in _os.listdir(this_dir):
-            path = _os.path.join(this_dir, basename)
-            if _os.path.isdir(path):
-                test_dirs.append(path)
 
         # we need standardized URLs, so change to `this_dir` and adjust paths
         _os.chdir(this_dir)
 
         # Generate test methods
-        for orig_path in test_dirs:
-            this_path = _os.path.relpath(orig_path, start=this_dir)
-            test_name = "test_email_{}".format(this_path.replace(".", "_").replace("-", "_"))
-            attrs[test_name] = cls.generate_test(this_path)
+        for test_config_path in _glob.glob("*/*.config"):
+            test_name = "test_email_{}".format(test_config_path)
+            attrs[test_name] = cls.generate_test(test_config_path)
 
         return super(TestEmailsMeta, cls).__new__(cls, name, bases, attrs)
 

--- a/test/test.py
+++ b/test/test.py
@@ -25,6 +25,11 @@ test_dir = _os.path.dirname(_os.path.abspath(__file__))
 # test.
 r2e_path = _os.path.join(test_dir, "..", "r2e")
 
+if not _os.path.isfile(r2e_path):
+    print("Couldn't find r2e script, existing files are: ")
+    print(_os.listdir(_os.path.join(test_dir, "..")))
+    sys.exit(1)
+
 # Ensure we import the local (not system-wide) rss2email module
 sys.path.insert(0, _os.path.dirname(r2e_path))
 import rss2email as _rss2email

--- a/test/test.py
+++ b/test/test.py
@@ -15,16 +15,19 @@ import unittest
 import mailbox
 import http.server
 import time
-
-import rss2email as _rss2email
-import rss2email.config as _rss2email_config
-import rss2email.feed as _rss2email_feed
+import sys
 
 # By default, we run the r2e in the dir above this script, not the
 # system-wide installed version, which you probably don't mean to
-# test
+# test.
 r2e_path = _os.path.join(_os.path.dirname(_os.path.abspath(__file__)),
                          "..", "r2e")
+
+# Ensure we import the local (not system-wide) rss2email module
+sys.path.insert(0, _os.path.dirname(r2e_path))
+import rss2email as _rss2email
+import rss2email.config as _rss2email_config
+import rss2email.feed as _rss2email_feed
 
 class TestEmails(unittest.TestCase):
     class Send (list):

--- a/test/test.py
+++ b/test/test.py
@@ -177,9 +177,10 @@ class ExecContext:
         subprocess.call([r2e_path, "-c", self.cfg_path, "-d", self.data_path] + list(args))
 
 class NoLogHandler(http.server.SimpleHTTPRequestHandler):
-    "No logging handler serving test feed data"
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs, directory=test_dir)
+    "No logging handler serving test feed data from test_dir"
+    def translate_path(self, path):
+        path = http.server.SimpleHTTPRequestHandler.translate_path(self, path)
+        return _os.path.join(test_dir, path)
 
     def log_message(self, format, *args):
         return

--- a/test/test.py
+++ b/test/test.py
@@ -22,13 +22,9 @@ test_dir = _os.path.dirname(_os.path.abspath(__file__))
 
 # By default, we run the r2e in the dir above this script, not the
 # system-wide installed version, which you probably don't mean to
-# test.
-r2e_path = _os.path.join(test_dir, "..", "r2e")
-
-if not _os.path.isfile(r2e_path):
-    print("Couldn't find r2e script, existing files are: ")
-    print(_os.listdir(_os.path.join(test_dir, "..")))
-    sys.exit(1)
+# test. You can also pass in an alternate location in the R2E_PATH
+# environment variable.
+r2e_path = _os.getenv("R2E_PATH", _os.path.join(test_dir, "..", "r2e"))
 
 # Ensure we import the local (not system-wide) rss2email module
 sys.path.insert(0, _os.path.dirname(r2e_path))


### PR DESCRIPTION
This PR corrects how the locking works, which caused issues in e.g. https://github.com/rss2email/rss2email/issues/83. The problem is outlined in a comment I wrote there but basically, the desired behaviour is that if there are multiple instances of r2e about, they should take it in turns to run and avoid all running at the same time, possibly mangling the data file or the config file.

I implement this by acquiring an exclusive lock on the data file right at the start and releasing it right at the end. As far as I can tell, this eliminates the error @ezbik was experiencing, but it's always possible I broke something else subtle.

Also, there is a branch that only happens if we're not on Solaris...I certainly hope no-one is.