### PR TITLE
Add --maximum option to run command, fix bugs in new user agent configurability

### DIFF
--- a/r2e.1
+++ b/r2e.1
@@ -67,7 +67,7 @@ optional \fI<email>\fR argument is the email address to send new items
 to, overriding the default address for this particular feed.  Repeat
 for each feed you want to subscribe to.
 .TP
-.B run \fR[\fI\-\-no-send\fR] \fR[\fI<index>\fR [\fI<index>\fR ...]]
+.B run \fR[\fI\-\-no-send\fR] \fR[\fI\-\-maximum <num>\fR] \fR[\fI<index>\fR [\fI<index>\fR ...]]
 Scan the feeds and send emails for new items. This can be run in a cron
 job.
 .P
@@ -75,6 +75,10 @@ job.
 The \-\-no-send option stops \fBr2e\fR from sending any email. This can be
 useful the first time you run it, as otherwise it would send an email
 for every available feed entry.
+.P
+The \-\-maximum option specifies the maximum number of items to
+process from each feed. Unprocessed items will be left to be processed
+in a future run.
 .P
 If an \fI<index>\fR is specified, \fBr2e\fR will only download that
 feed. \fI<index>\fR can be either the feed name (as set by \fBadd\fR)

--- a/rss2email/command.py
+++ b/rss2email/command.py
@@ -84,7 +84,7 @@ def run(feeds, args):
                             interval = interval
                         ))
                         _time.sleep(interval)
-                    feed.run(send=args.send)
+                    feed.run(send=args.send, maximum=args.maximum)
                 except _error.RSS2EmailError as e:
                     e.log()
                 last_server = current_server

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -168,6 +168,9 @@ class Feed (object):
     _default_configured_attributes[
         _default_configured_attributes.index('from')
         ] = 'from_email'  # `from` is a Python keyword
+    _default_configured_attributes[
+        _default_configured_attributes.index('user_agent')
+        ] = '_user_agent'  # `user_agent` is a getter that does substitution
     # all attributes that are saved/loaded from .config
     _configured_attributes = (
         _non_default_configured_attributes + _default_configured_attributes)
@@ -213,6 +216,12 @@ class Feed (object):
         'digest_post_process',
         ]
 
+    @property
+    def user_agent(self):
+        return self._user_agent.\
+            replace('__VERSION__', __version__).\
+            replace('__URL__', __url__)
+
     def __init__(self, name=None, url=None, to=None, config=None):
         self._set_name(name=name)
         self.reset()
@@ -224,8 +233,6 @@ class Feed (object):
             self.url = url
         if to:
             self.to = to
-        self.user_agent = self.user_agent.replace('__VERSION__', __version__)
-        self.user_agent = self.user_agent.replace('__URL__', __url__)
 
     def __str__(self):
         return '{} ({} -> {})'.format(self.name, self.url, self.to)

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -99,6 +99,10 @@ def run(*args, **kwargs):
         default=True, action='store_const', const=False,
         help="fetch feeds, but don't send email")
     run_parser.add_argument(
+        '-m', '--maximum', dest='maximum',
+        action='store', type=int,
+        help="Maximum number of new items to process for each feed")
+    run_parser.add_argument(
         'index', nargs='*',
         help='feeds to fetch (defaults to fetching all feeds)')
 

--- a/rss2email/post_process/redirect.py
+++ b/rss2email/post_process/redirect.py
@@ -61,7 +61,7 @@ def process(feed, parsed, entry, guid, message):
     for link in links:
         try:
             request = urllib.request.Request(link)
-            request.add_header('User-agent', rss2email.feed._USER_AGENT)
+            request.add_header('User-agent', feed.user_agent)
             direct_link = urllib.request.urlopen(request).geturl()
         except Exception as e:
             LOG.warning('could not follow redirect for {}: {}'.format(


### PR DESCRIPTION
The first commit in this PR adds a new option to the `run` command, `--maximum`, which specifies the maximum number of new entries to process for each feed. This is useful for people who want to avoid getting big bursts of email from feeds that tend to add many entries at once, and also useful during development and debugging so you can use a real feed during testing without getting a ton of emails every time you test.

The rest of the commits are various fixes to the functionality added in release 3.11 to allow the user agent string to be configured. See the descriptions of the individual commits for details.