### PR TITLE
test/README: fix command invocation

### DIFF
--- a/test/README
+++ b/test/README
@@ -1,6 +1,8 @@
 Run tests with::
 
-  $ PYTHONPATH=. ./test/test.py
+  $ env "PATH=$(pwd):$PATH" "PYTHONPATH=$(pwd):$PYTHONPATH" ./test/test.py
+
+… from the root of the project.
 
 Which looks for any ``*/feed.*`` files and processes them using each
 ``*.config`` file in the feed's directory.  The output messages are
@@ -37,9 +39,9 @@ feed/config pair.  For example, with a directory structure like::
 If you only want to limit yourself to a subset of tests, you can
 specify subdirectories on the command line::
 
-  $ PYTHONPATH=. ./test/test.py test/allthingsrss
+  $ env "PATH=$(pwd):$PATH" "PYTHONPATH=$(pwd):$PYTHONPATH" ./test/test.py test/allthingsrss
 
 You can limit the tests even further by specify particular config
 files::
 
-  $ PYTHONPATH=. ./test/test.py test/allthingsrss/1.config
+  $ env "PATH=$(pwd):$PATH" "PYTHONPATH=$(pwd):$PYTHONPATH" ./test/test.py test/allthingsrss test/allthingsrss/1.config


### PR DESCRIPTION
The r2e binary needs to be in scope for the tests to work.
Also, PYTHONPATH should not be overwritten.