### PR TITLE
Fixes to the configurable user-agent changes introduced in 3.11

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -168,6 +168,9 @@ class Feed (object):
     _default_configured_attributes[
         _default_configured_attributes.index('from')
         ] = 'from_email'  # `from` is a Python keyword
+    _default_configured_attributes[
+        _default_configured_attributes.index('user_agent')
+        ] = '_user_agent'  # `user_agent` is a getter that does substitution
     # all attributes that are saved/loaded from .config
     _configured_attributes = (
         _non_default_configured_attributes + _default_configured_attributes)
@@ -213,6 +216,12 @@ class Feed (object):
         'digest_post_process',
         ]
 
+    @property
+    def user_agent(self):
+        return self._user_agent.\
+            replace('__VERSION__', __version__).\
+            replace('__URL__', __url__)
+
     def __init__(self, name=None, url=None, to=None, config=None):
         self._set_name(name=name)
         self.reset()
@@ -224,8 +233,6 @@ class Feed (object):
             self.url = url
         if to:
             self.to = to
-        self.user_agent = self.user_agent.replace('__VERSION__', __version__)
-        self.user_agent = self.user_agent.replace('__URL__', __url__)
 
     def __str__(self):
         return '{} ({} -> {})'.format(self.name, self.url, self.to)

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -229,6 +229,7 @@ class Feed (object):
                 (attr, getattr(self, attr))
                 for attr in self._dynamic_attributes))
         self.load_from_config(config=config)
+        self._fix_user_agent() # Fix feeds broken by user agent change in 3.11
         if url:
             self.url = url
         if to:
@@ -910,3 +911,21 @@ class Feed (object):
             if guid not in self.seen:
                 self.seen[guid] = {}
             self.seen[guid]['id'] = id_
+
+    def _fix_user_agent(self):
+        """Fix feed user agent settings broken in 3.11
+
+        Release 3.11 added code to allow the user agent string to be
+        configured globally and on a per-feed basis. It was supposed
+        to allow __VERSION__ and __URL__ in configuration setting to
+        be substituted dynamically with the current version and URL of
+        rss2email, but a bug in the implementation caused them to be
+        substituted statically in the settings for any newly added
+        feed. We've fixed that problem, but we want to go back now and
+        repair feeds that got the wrong user agent value in the
+        interim.
+        """
+        if self._user_agent == \
+           'rss2email/3.11 (https://github.com/rss2email/rss2email)':
+            self._user_agent = 'rss2email/__VERSION__ (__URL__)'
+            self.save_to_config()

--- a/rss2email/post_process/redirect.py
+++ b/rss2email/post_process/redirect.py
@@ -61,7 +61,7 @@ def process(feed, parsed, entry, guid, message):
     for link in links:
         try:
             request = urllib.request.Request(link)
-            request.add_header('User-agent', rss2email.feed._USER_AGENT)
+            request.add_header('User-agent', feed.user_agent)
             direct_link = urllib.request.urlopen(request).geturl()
         except Exception as e:
             LOG.warning('could not follow redirect for {}: {}'.format(


### PR DESCRIPTION
This PR is the first few commits of #97, plus two tests that:

* The substituted values aren't written to the config file when you add a new feed

* Old badly substituted per-feed configs are corrected (this only happens if you added a feed in v3.11 and had the default user agent)

I think there's still some other stuff in #97 that would be good to pick up, mostly test improvements, but I think these bug fixes should be merged first. I'll make a PR later on to improve tests, I've done a bit of that in #94, but smaller PRs are easier to review (and take less time to make).

cc @jikamens