### PR TITLE
Include feed info in error message when fetch times out

### DIFF
--- a/rss2email/error.py
+++ b/rss2email/error.py
@@ -43,13 +43,15 @@ class RSS2EmailError (Exception):
 class TimeoutError (RSS2EmailError):
     def __init__(self, time_limited_function, message=None):
         if message is None:
-            if time_limited_function.error is not None:
-                message = (
-                    'error while running time limited function: {}'.format(
-                        time_limited_function.error[1]))
-            else:
-                message = '{} second timeout exceeded'.format(
-                    time_limited_function.timeout)
+            message = ''
+        else:
+            message += ': '
+        if time_limited_function.error is not None:
+            message += 'error while running time limited function: {}'.format(
+                time_limited_function.error[1])
+        else:
+            message += '{} second timeout exceeded'.format(
+                time_limited_function.timeout)
         super(TimeoutError, self).__init__(message=message)
         self.time_limited_function = time_limited_function
 

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -356,7 +356,7 @@ class Feed (object):
         kwargs = {}
         if proxy:
             kwargs['handlers'] = [_urllib_request.ProxyHandler({'http':proxy})]
-        f = _util.TimeLimitedFunction(timeout, _feedparser.parse)
+        f = _util.TimeLimitedFunction(timeout, _feedparser.parse, message=str(self))
         return f(self.url, self.etag, modified=self.modified, **kwargs)
 
     def _process(self, parsed):

--- a/rss2email/util.py
+++ b/rss2email/util.py
@@ -43,11 +43,12 @@ class TimeLimitedFunction (_threading.Thread):
       ...
     rss2email.error.TimeoutError: error while running time limited function: a float is required
     """
-    def __init__(self, timeout, target, **kwargs):
+    def __init__(self, timeout, target, message=None, **kwargs):
         super(TimeLimitedFunction, self).__init__(target=target, daemon=True, **kwargs)
         self.timeout = timeout
         self.result = None
         self.error = None
+        self.message = message
 
     def run(self):
         """Based on Thread.run().
@@ -71,9 +72,9 @@ class TimeLimitedFunction (_threading.Thread):
         self.join(self.timeout)
         if self.error:
             raise _error.TimeoutError(
-                time_limited_function=self) from self.error[1]
+                time_limited_function=self, message=self.message) from self.error[1]
         elif self.is_alive():
-            raise _error.TimeoutError(time_limited_function=self)
+            raise _error.TimeoutError(time_limited_function=self, message=self.message)
         return self.result
 
 


### PR DESCRIPTION
Before this change, when a feed times out, this is the error the user sees:

```
2020-03-07 10:01:02,784 [ERROR] 60 second timeout exceeded
```

This is unhelpful.

This commit modifies the behavior so that the feed information appears in the error:

```
2020-03-07 10:05:05,697 [ERROR] [feed-name] ([url] -> [email]): 60 second timeout exceeded
```