### PR TITLE
add encode-date-field option to disable encoding for MUA's that lack support

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -45,12 +45,14 @@
 """Define the ``Feed`` class for handling a single feed
 """
 
+import calendar as _calendar
 import collections as _collections
 import platform
 from email.message import Message
 from email.mime.message import MIMEMessage as _MIMEMessage
 from email.mime.multipart import MIMEMultipart as _MIMEMultipart
 from email.utils import formataddr as _formataddr
+from email.utils import formatdate as _formatdate
 from email.utils import parseaddr as _parseaddr
 import hashlib as _hashlib
 import html.parser as _html_parser
@@ -609,7 +611,7 @@ class Feed (object):
                 if entry.get(kind, None):
                     datetime = entry[kind]
                     break
-        return _time.strftime("%a, %d %b %Y %H:%M:%S -0000", datetime)
+        return _formatdate(_calendar.timegm(datetime))
 
     def _get_entry_name(self, parsed, entry):
         """Get the best name


### PR DESCRIPTION
Not all MUA's support encoded date fields, Mutt doesn't and Thunderbird might not unless fixed since https://bugzilla.mozilla.org/show_bug.cgi?id=276199 decided it was an RFC violation.