### PR TITLE
Add GitHub action to build and run tests on Ubuntu, Windows and macOS

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
         python-version: [3.5, 3.6, 3.7, 3.8]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,31 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Test
+      run: |
+        ./test/test.py -v

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# This workflow will install Python dependencies and run tests.
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 name: Python package

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+feedparser==5.2.1
+html2text==2020.1.16


### PR DESCRIPTION
This change comes after I saw #112 where a bug completely broke rss2email on Windows. We should run the tests on Windows and macOS to make sure this doesn't happen, since I'm only testing on Debian. I didn't do this through Travis since Travis doesn't support Python on Windows or macOS.

After this is merged, I think we should get rid of Travis CI completely, since it would be redundant and is in fact strictly worse than what is provided by GitHub actions. Also, my opinion is that the CI is much easier to understand if it's literally just `pip install -r requirements.txt; ./test/test.py -v` from a clean machine, since this is what I'm doing locally.

To see what a run of this looks like, see here for an example: https://github.com/kaashif/rss2email/runs/745685834