### PR TITLE
add List-{ID,Post} headers to emails

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -478,6 +478,8 @@ class Feed (object):
                 ('Date', self._get_entry_date(entry)),
                 ('Message-ID', '<{}@dev.null.invalid>'.format(_uuid.uuid4())),
                 ('User-Agent', self.user_agent),
+                ('List-ID', '<{}.localhost>'.format(self.name)),
+                ('List-Post', 'NO (posting not allowed on this list)'),
                 ('X-RSS-Feed', self.url),
                 ('X-RSS-ID', guid),
                 ('X-RSS-URL', self._get_entry_link(entry)),
@@ -884,6 +886,8 @@ class Feed (object):
         digest['Subject'] = 'digest for {}'.format(self.name)
         digest['Message-ID'] = '<{}@dev.null.invalid>'.format(_uuid.uuid4())
         digest['User-Agent'] = self.user_agent
+        digest['List-ID'] = '<{}.localhost>'.format(self.name)
+        digest['List-Post'] = 'NO (posting not allowed on this list)'
         digest['X-RSS-Feed'] = self.url
         return digest
 

--- a/test/allthingsrss/1.expected
+++ b/test/allthingsrss/1.expected
@@ -8,6 +8,8 @@ Subject: Version 2.67 Released
 Date: Tue, 21 Sep 2010 16:55:07 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=62
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/aGbf5Gefkmc/
@@ -47,6 +49,8 @@ Subject: Version 2.68 Released with Actual New Features
 Date: Fri, 01 Oct 2010 18:21:26 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=72
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/bT-I0iH2vw8/
@@ -92,6 +96,8 @@ Subject: How to Read RSS Feeds in Emacs
 Date: Fri, 05 Nov 2010 17:36:14 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=79
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/JryfOLe_q6c/

--- a/test/allthingsrss/2.expected
+++ b/test/allthingsrss/2.expected
@@ -8,6 +8,8 @@ Subject: Version 2.67 Released
 Date: Tue, 21 Sep 2010 16:55:07 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=62
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/aGbf5Gefkmc/
@@ -47,6 +49,8 @@ Subject: Version 2.68 Released with Actual New Features
 Date: Fri, 01 Oct 2010 18:21:26 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=72
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/bT-I0iH2vw8/
@@ -92,6 +96,8 @@ Subject: How to Read RSS Feeds in Emacs
 Date: Fri, 05 Nov 2010 17:36:14 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=79
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/JryfOLe_q6c/

--- a/test/allthingsrss/3.expected
+++ b/test/allthingsrss/3.expected
@@ -8,6 +8,8 @@ Content-Transfer-Encoding: 7bit
 Date: Tue, 21 Sep 2010 16:55:07 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=62
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/aGbf5Gefkmc/
@@ -48,6 +50,8 @@ Content-Transfer-Encoding: 7bit
 Date: Fri, 01 Oct 2010 18:21:26 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=72
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/bT-I0iH2vw8/
@@ -94,6 +98,8 @@ Content-Transfer-Encoding: 7bit
 Date: Fri, 05 Nov 2010 17:36:14 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=79
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/JryfOLe_q6c/

--- a/test/allthingsrss/4.expected
+++ b/test/allthingsrss/4.expected
@@ -8,6 +8,8 @@ Content-Transfer-Encoding: 7bit
 Date: Tue, 21 Sep 2010 16:55:07 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: test string
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=62
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/aGbf5Gefkmc/
@@ -48,6 +50,8 @@ Content-Transfer-Encoding: 7bit
 Date: Fri, 01 Oct 2010 18:21:26 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: test string
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=72
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/bT-I0iH2vw8/
@@ -94,6 +98,8 @@ Content-Transfer-Encoding: 7bit
 Date: Fri, 05 Nov 2010 17:36:14 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: test string
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: allthingsrss/feed.atom
 X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=79
 X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/JryfOLe_q6c/

--- a/test/bbc-chinese/1.expected
+++ b/test/bbc-chinese/1.expected
@@ -8,6 +8,8 @@ Subject: =?utf-8?b?5Zu96ZmF6LSn5biB5Z+66YeR57uE57uH56ew5YWo55CD57uP5rWO5oGi5aSN5
 Date: Wed, 23 Jan 2013 20:50:57 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: bbc-chinese/feed.atom
 X-RSS-ID: tag:www.bbcchinese.com,2013-01-23:22535346
 X-RSS-URL: http://www.bbc.co.uk/zhongwen/simp/world/2013/01/130123_imf_world_economy.shtml
@@ -29,6 +31,8 @@ Subject: =?utf-8?b?55m95a6r5o+Q5ZCN6Im+5Lym5Li65YyX57qm5pyA6auY5Y+45Luk5a6Y?=
 Date: Wed, 23 Jan 2013 20:55:42 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: bbc-chinese/feed.atom
 X-RSS-ID: tag:www.bbcchinese.com,2013-01-23:22535477
 X-RSS-URL: http://www.bbc.co.uk/zhongwen/simp/world/2013/01/130123_us_genallen_nato.shtml

--- a/test/bbc-chinese/2.expected
+++ b/test/bbc-chinese/2.expected
@@ -8,6 +8,8 @@ Content-Transfer-Encoding: base64
 Date: Wed, 23 Jan 2013 20:50:57 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: bbc-chinese/feed.atom
 X-RSS-ID: tag:www.bbcchinese.com,2013-01-23:22535346
 X-RSS-URL: http://www.bbc.co.uk/zhongwen/simp/world/2013/01/130123_imf_world_economy.shtml
@@ -29,6 +31,8 @@ Content-Transfer-Encoding: base64
 Date: Wed, 23 Jan 2013 20:55:42 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: bbc-chinese/feed.atom
 X-RSS-ID: tag:www.bbcchinese.com,2013-01-23:22535477
 X-RSS-URL: http://www.bbc.co.uk/zhongwen/simp/world/2013/01/130123_us_genallen_nato.shtml

--- a/test/disqus/1.expected
+++ b/test/disqus/1.expected
@@ -8,6 +8,8 @@ Subject: Re: Who Wants To Write a Little Code?
 Date: Sat, 17 Nov 2012 11:21:26 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: disqus/feed.rss
 X-RSS-ID: 82a71554e460103fdd7350c4ae84f7518386d4f8
 X-RSS-URL: http://software-carpentry.org/2012/11/who-wants-to-write-a-little-code/#comment-713578641
@@ -38,6 +40,8 @@ Subject: Re: Who Wants To Write a Little Code?
 Date: Sat, 17 Nov 2012 14:01:27 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: disqus/feed.rss
 X-RSS-ID: ab03f2100069a1cd0876b997be87976c18d48e8a
 X-RSS-URL: http://software-carpentry.org/2012/11/who-wants-to-write-a-little-code/#comment-713578640

--- a/test/gmane/1.expected
+++ b/test/gmane/1.expected
@@ -8,6 +8,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Mon, 12 Nov 2012 21:20:22 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/1
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/1
@@ -58,6 +60,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Tue, 13 Nov 2012 10:48:07 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/2
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/2
@@ -98,6 +102,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Tue, 13 Nov 2012 12:20:20 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/3
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/3
@@ -121,6 +127,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Tue, 13 Nov 2012 12:42:13 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/4
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/4
@@ -148,6 +156,8 @@ Subject: split massive package into modules
 Date: Tue, 13 Nov 2012 14:36:22 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/5
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/5

--- a/test/gmane/2.expected
+++ b/test/gmane/2.expected
@@ -5,6 +5,8 @@ To: a@b.com
 Subject: digest for test
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 From: "gmane.mail.rss2email: W. Trevor King" <user@rss2email.invalid>
 Date: Tue, 13 Nov 2012 14:36:22 -0000
@@ -23,6 +25,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Mon, 12 Nov 2012 21:20:22 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/1
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/1
@@ -76,6 +80,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Tue, 13 Nov 2012 10:48:07 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/2
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/2
@@ -119,6 +125,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Tue, 13 Nov 2012 12:20:20 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/3
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/3
@@ -145,6 +153,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Tue, 13 Nov 2012 12:42:13 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/4
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/4
@@ -175,6 +185,8 @@ Subject: split massive package into modules
 Date: Tue, 13 Nov 2012 14:36:22 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/5
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/5

--- a/test/gmane/3.expected
+++ b/test/gmane/3.expected
@@ -8,6 +8,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Mon, 12 Nov 2012 21:20:22 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/1
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/1
@@ -68,6 +70,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Tue, 13 Nov 2012 10:48:07 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/2
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/2
@@ -118,6 +122,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Tue, 13 Nov 2012 12:20:20 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/3
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/3
@@ -152,6 +158,8 @@ Subject: Re: new maintainer and mailing list for rss2email
 Date: Tue, 13 Nov 2012 12:42:13 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/4
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/4
@@ -189,6 +197,8 @@ Subject: split massive package into modules
 Date: Tue, 13 Nov 2012 14:36:22 -0000
 Message-ID: <...@dev.null.invalid>
 User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
 X-RSS-Feed: gmane/feed.rss
 X-RSS-ID: http://permalink.gmane.org/gmane.mail.rss2email/5
 X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/5


### PR DESCRIPTION
This patch populates some standard List headers as defined in RFC2919 and RFC2369.
Those are commonly recognised by some MUAs, allowing automatic tagging and sorting.