### PR TITLE
Set log level from configuration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,7 @@ UNRELEASED
     * Remove documentation of `smtp-ssl-protocol` as this option was dropped in 2016
     * Stop forging SMTP and sendmail envelope sender (#134)
     * Add sendmail_config option
+    * Fix verbose configuration setting
 
 v3.12.2 (2020-08-31)
     * Fix bug `AttributeError: 'NoneType' object has no attribute 'close'` (#126)

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -183,6 +183,8 @@ def run(*args, **kwargs):
         feeds = _feeds.Feeds(datafile_path=args.data, configfiles=args.config)
         if args.func != _command.new:
             feeds.load()
+        if not args.verbose:
+            _LOG.setLevel(feeds.config['DEFAULT']['verbose'].upper())
         args.func(feeds=feeds, args=args)
     except _error.RSS2EmailError as e:
         e.log()

--- a/test/test.py
+++ b/test/test.py
@@ -364,6 +364,24 @@ class TestFeedConfig(unittest.TestCase):
             for line in lines[feed_cfg_start:]:
                 self.assertFalse("user-agent" in line)
 
+    def test_verbose_setting_debug(self):
+        "Verbose setting set to debug in configuration should be respected"
+        cfg = """[DEFAULT]
+        verbose = debug
+        """
+        with ExecContext(cfg) as ctx:
+            p = ctx.call("run", "--no-send")
+            self.assertIn('[DEBUG]', p.stderr)
+
+    def test_verbose_setting_info(self):
+        "Verbose setting set to info in configuration should be respected"
+        cfg = """[DEFAULT]
+        verbose = info
+        """
+        with ExecContext(cfg) as ctx:
+            p = ctx.call("run", "--no-send")
+            self.assertNotIn('[DEBUG]', p.stderr)
+
 class TestOPML(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super(TestOPML, self).__init__(*args, **kwargs)
@@ -393,15 +411,15 @@ class TestOPML(unittest.TestCase):
 
     def test_opml_export_without_arg(self):
         with ExecContext(self.cfg) as ctx:
-            # This is just a smoke test for now, it'd be better to capture
+            # This is just a smoke test for now, it'd be better to check
             # stdout but this is enough to check for non-regression
             res = ctx.call("opmlexport")
-            self.assertEqual(res, 0)
+            self.assertEqual(res.returncode, 0)
 
             ctx.call("add", self.feed_name, self.feed_url)
 
             res = ctx.call("opmlexport")
-            self.assertEqual(res, 0)
+            self.assertEqual(res.returncode, 0)
 
     def test_opml_import(self):
         with ExecContext(self.cfg) as ctx:

--- a/test/util/execcontext.py
+++ b/test/util/execcontext.py
@@ -36,7 +36,11 @@ class ExecContext:
         self._tmpdir.cleanup()
 
     def call(self, *args):
-        return subprocess.call([sys.executable, r2e_path, "-c", str(self.cfg_path), "-d", str(self.data_path)] + list(args))
+        return subprocess.run(
+            [sys.executable, r2e_path, "-c", str(self.cfg_path), "-d", str(self.data_path)] + list(args),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True)
 
     def change_config(self, params: Dict[str, Any]) -> None:
         config = ConfigParser()


### PR DESCRIPTION
The verbose setting specified in the configuration file doesn't seem to
actually set the log level anywhere.