### PR TITLE
Add sendmail_config option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ UNRELEASED
     * Improve log messages
     * Remove documentation of `smtp-ssl-protocol` as this option was dropped in 2016
     * Stop forging SMTP and sendmail envelope sender (#134)
+    * Add sendmail_config option
 
 v3.12.2 (2020-08-31)
     * Fix bug `AttributeError: 'NoneType' object has no attribute 'close'` (#126)

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -208,6 +208,7 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         # True: Use SMTP_SERVER to send mail.
         # Sendmail (or compatible) configuration
         ('sendmail', '/usr/sbin/sendmail'),  # Path to sendmail (or compatible)
+        ('sendmail_config', ''),
         # SMTP configuration
         ('smtp-auth', str(False)),      # set to True to use SMTP AUTH
         ('smtp-username', 'username'),  # username for SMTP AUTH

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -349,13 +349,16 @@ def sendmail_send(recipient, message, config=None, section='DEFAULT'):
     if config is None:
         config = _config.CONFIG
     message_bytes = _flatten(message)
-    sendmail = config.get(section, 'sendmail')
+    sendmail = [config.get(section, 'sendmail')]
+    sendmail_config = config.get(section, 'sendmail_config')
+    if sendmail_config:
+        sendmail.extend(['-C', sendmail_config])
     sender_name,sender_addr = _parseaddr(config.get(section, 'from'))
     _LOG.debug(
         'sending message to {} via {}'.format(recipient, sendmail))
     try:
         p = _subprocess.Popen(
-            [sendmail, '-F', sender_name, '-f', sender_addr, recipient],
+            sendmail + ['-F', sender_name, '-f', sender_addr, recipient],
             stdin=_subprocess.PIPE, stdout=_subprocess.PIPE,
             stderr=_subprocess.PIPE)
         stdout,stderr = p.communicate(message_bytes)


### PR DESCRIPTION
This takes a path to a sendmail configuration file in case one does not
want to use the global configuration.