### PR TITLE
Log sendmail output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ UNRELEASED
     * Fix verbose configuration setting
     * Upgraded to feedparser v6.0 (https://github.com/kurtmckee/feedparser/)
     * Drop support for Python 3.5
+    * Log sendmail output
 
 v3.12.2 (2020-08-31)
     * Fix bug `AttributeError: 'NoneType' object has no attribute 'close'` (#126)

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -38,6 +38,7 @@ from email.header import Header as _Header
 from email.mime.text import MIMEText as _MIMEText
 from email.utils import formataddr as _formataddr
 from email.utils import parseaddr as _parseaddr
+import logging
 import mailbox as _mailbox
 from email.utils import getaddresses as _getaddresses
 import imaplib as _imaplib
@@ -360,12 +361,14 @@ def sendmail_send(recipient, message, config=None, section='DEFAULT'):
         p = _subprocess.Popen(
             sendmail + ['-F', sender_name, '-f', sender_addr, recipient],
             stdin=_subprocess.PIPE, stdout=_subprocess.PIPE,
-            stderr=_subprocess.PIPE)
-        stdout,stderr = p.communicate(message_bytes)
+            stderr=_subprocess.STDOUT)
+        stdout, _ = p.communicate(message_bytes)
         status = p.wait()
+        _LOG.debug(stdout.decode())
         if status:
-            raise _error.SendmailError(
-                status=status, stdout=stdout, stderr=stderr)
+            if _LOG.level > logging.DEBUG:
+                _LOG.error(stdout.decode())
+            raise _error.SendmailError(status=status)
     except Exception as e:
         raise _error.SendmailError() from e
 

--- a/rss2email/error.py
+++ b/rss2email/error.py
@@ -117,15 +117,12 @@ class IMAPAuthenticationError (IMAPConnectionError):
 
 
 class SendmailError (RSS2EmailError):
-    def __init__(self, status=None, stdout=None, stderr=None):
+    def __init__(self, status=None):
         if status:
             message = 'sendmail exited with code {}'.format(status)
         else:
             message = ''
         super(SendmailError, self).__init__(message=message)
-        self.status = status
-        self.stdout = stdout
-        self.stderr = stderr
 
     def log(self):
         super(SendmailError, self).log()

--- a/test/util/tempsendmail.py
+++ b/test/util/tempsendmail.py
@@ -1,0 +1,30 @@
+import os
+import tempfile
+from pathlib import Path
+
+
+class TemporarySendmail:
+    def __init__(self, exitcode):
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+        _config = tempfile.NamedTemporaryFile(
+            dir=self._tmpdir.name, delete=False)
+        self.config = Path(_config.name)
+
+        with tempfile.NamedTemporaryFile(
+                dir=self._tmpdir.name, delete=False) as _bin:
+            _bin.write(
+                b'''#!/usr/bin/env sh
+                echo "Sendmail failing for reasons..."
+                exit %s''' % bytes(str(exitcode), 'utf-8'))
+        self.bin = Path(_bin.name)
+        os.chmod(str(self.bin), 0o700)
+
+    def cleanup(self):
+        self._tmpdir.cleanup()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.cleanup()


### PR DESCRIPTION
There's really no way to debug a broken sendmail setup when the output
is thrown away. Stdout and stderr were passed to the exception as
attributes but do not appear to be used there.

I don't believe there's any other good way to merge stdout/stderr and
preserve the sequential order than to pass one to the other and the
other to PIPE.