### PR TITLE
Make read_configfiles a local variable

### DIFF
--- a/rss2email/feeds.py
+++ b/rss2email/feeds.py
@@ -239,11 +239,10 @@ class Feeds (list):
     def load(self, require=False):
         _LOG.debug('load feed configuration from {}'.format(self.configfiles))
         if self.configfiles:
-            self.read_configfiles = self.config.read(self.configfiles)
+            read_configfiles = self.config.read(self.configfiles)
         else:
-            self.read_configfiles = []
-        _LOG.debug('loaded configuration from {}'.format(
-                self.read_configfiles))
+            read_configfiles = []
+        _LOG.debug('loaded configuration from {}'.format(read_configfiles))
         self._load_feeds(require=require)
 
     def _load_feeds(self, require):


### PR DESCRIPTION
It doesn't seem to be used anywhere else in the code base.