### PR TITLE
Force the From address by default

### DIFF
--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -85,7 +85,7 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ('use-8bit', str(False)),
         # True: Only use the 'from' address.
         # False: Use the email address specified by the feed, when possible.
-        ('force-from', str(False)),
+        ('force-from', str(True)),
         # True: Use the publisher's email if you can't find the author's.
         # False: Just use the 'from' email instead.
         ('use-publisher-email', str(False)),

--- a/test/data/bbc-chinese/2.config
+++ b/test/data/bbc-chinese/2.config
@@ -2,3 +2,4 @@
 to = a@b.com
 date-header = True
 use-8bit = True
+force-from = False

--- a/test/data/bbc-chinese/3.config
+++ b/test/data/bbc-chinese/3.config
@@ -1,4 +1,4 @@
 [DEFAULT]
 to = a@b.com
 date-header = True
-force-from = False
+use-8bit = True

--- a/test/data/bbc-chinese/3.expected
+++ b/test/data/bbc-chinese/3.expected
@@ -1,0 +1,46 @@
+SENT BY: =?utf-8?b?YmJjY2hpbmVzZS5jb20gfCDkuLvpobU6IEJCQyBDaGluZXNl?= <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+From: =?utf-8?b?YmJjY2hpbmVzZS5jb20gfCDkuLvpobU6IEJCQyBDaGluZXNl?= <user@rss2email.invalid>
+To: a@b.com
+Subject: =?utf-8?b?5Zu96ZmF6LSn5biB5Z+66YeR57uE57uH56ew5YWo55CD57uP5rWO5oGi5aSN5pS+57yT?=
+Content-Transfer-Encoding: base64
+Date: Wed, 23 Jan 2013 20:50:57 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/bbc-chinese/feed.atom
+X-RSS-ID: tag:www.bbcchinese.com,2013-01-23:22535346
+X-RSS-URL: http://www.bbc.co.uk/zhongwen/simp/world/2013/01/130123_imf_world_economy.shtml
+X-RSS-TAGS: =?utf-8?b?Y2hpbmVzZV9zaW1wbGlmaWVkLHdvcmxkLOS4lueVjOmTtuihjO+8jCDmiqXlkYrvvIwg57uP5rWO5Y+R5bGV?=
+
+5Zu96ZmF6LSn5biB5Z+66YeR57uE57uH77yISU1G77yJ6K2m5ZGK6K+077yM5bC9566h5ZCE5Zu9
+5pS/5bqc6YeH5Y+W5o6q5pa95Yi65r+A57uP5rWO77yM5L2G5YWo55CD57uP5rWO5oGi5aSN6YCf
+5bqm5q2j5Zyo5YeP5byx44CCCgpVUkw6IGh0dHA6Ly93d3cuYmJjLmNvLnVrL3pob25nd2VuL3Np
+bXAvd29ybGQvMjAxMy8wMS8xMzAxMjNfaW1mX3dvcmxkX2Vjb25vbXkuc2h0bWw=
+
+
+SENT BY: =?utf-8?b?YmJjY2hpbmVzZS5jb20gfCDkuLvpobU6IEJCQyBDaGluZXNl?= <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+From: =?utf-8?b?YmJjY2hpbmVzZS5jb20gfCDkuLvpobU6IEJCQyBDaGluZXNl?= <user@rss2email.invalid>
+To: a@b.com
+Subject: =?utf-8?b?55m95a6r5o+Q5ZCN6Im+5Lym5Li65YyX57qm5pyA6auY5Y+45Luk5a6Y?=
+Content-Transfer-Encoding: base64
+Date: Wed, 23 Jan 2013 20:55:42 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/bbc-chinese/feed.atom
+X-RSS-ID: tag:www.bbcchinese.com,2013-01-23:22535477
+X-RSS-URL: http://www.bbc.co.uk/zhongwen/simp/world/2013/01/130123_us_genallen_nato.shtml
+X-RSS-TAGS: =?utf-8?b?Y2hpbmVzZV9zaW1wbGlmaWVkLHdvcmxkLOe+juWbve+8jOWMl+e6pu+8jOWbvemYsumDqO+8jOmpu+mYv+WvjOaxl+e+juWGm+WPuOS7pOWumO+8jOS4reWkruaDheaKpeWxgO+8jOWpmuWkluaDhQ==?=
+
+576O5Zu955m95a6r56ew77yM5bCG5o+Q5ZCN6am76Zi/5a+M5rGX576O5Yab5Y+45Luk5a6Y57qm
+57+w4oCn6Im+5Lym5Li65YyX57qm5pyA6auY5Y+45Luk5a6Y44CC6Im+5Lym5pu+5Zug5Y+X5oyH
+56ew5ZCM5LiA5aWz5oCn5pyJ4oCc5LiN5b2T4oCd6YKu5Lu25p2l5b6A6ICM6KKr6LCD5p+l44CC
+CgpVUkw6IGh0dHA6Ly93d3cuYmJjLmNvLnVrL3pob25nd2VuL3NpbXAvd29ybGQvMjAxMy8wMS8x
+MzAxMjNfdXNfZ2VuYWxsZW5fbmF0by5zaHRtbA==
+


### PR DESCRIPTION
Blog authors may get bounces with the default configuration, this changes the default configuration to send bounces to the email address configured (user@rss2email.invalid by default)


See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=968875 for the original report.
