### PR TITLE
Always use the 'from' setting for smtp and sendmail envelope.

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -871,7 +871,7 @@ class Feed (object):
         section = self.section
         if section not in self.config:
             section = 'DEFAULT'
-        _email.send(sender=sender, recipient=self.to, message=message,
+        _email.send(recipient=self.to, message=message,
                     config=self.config, section=section)
 
     def run(self, send=True):


### PR DESCRIPTION
Email addresses from the RSS feed must never be used as the envelope `From` address. Doing so causes bounces to be sent to feed authors instead of the user running rss2email.

Fixes https://github.com/rss2email/rss2email/issues/134

Replaces https://github.com/rss2email/rss2email/pull/135