### PR TITLE
Create lockfile in an user-specific directory

### DIFF
--- a/r2e.1
+++ b/r2e.1
@@ -302,6 +302,10 @@ $HOME/\&.config.
 The preferred directory for data files.  Defaults to
 $HOME/\&.local/share.
 .TP
+.B XDG_RUNTIME_DIR
+The preferred directory for lockfiles.  Defaults to
+/tmp/rss2email-UID
+.TP
 .B XDG_CONFIG_DIRS
 A colon ':' separated, preference ordered list of base directories for
 configuration files in addition to $XDG_CONFIG_HOME.  Defaults to

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -169,7 +169,12 @@ def run(*args, **kwargs):
     # Immediately lock so only one r2e instance runs at a time
     if UNIX:
         import fcntl as _fcntl
-        lockfile_path = _os.path.join(_os.environ.get("XDG_RUNTIME_DIR", default="/tmp/"), "rss2email.lock")
+        from pathlib import Path as _Path
+        dir = _os.environ.get("XDG_RUNTIME_DIR")
+        if dir is None:
+            dir = _os.path.join("/tmp", "rss2email-{}".format(_os.getuid()))
+            _Path(dir).mkdir(mode=0o700, parents=True, exist_ok=True)
+        lockfile_path = _os.path.join(dir, "rss2email.lock")
         lockfile = open(lockfile_path, "w")
         _fcntl.lockf(lockfile, _fcntl.LOCK_EX)
         _LOG.debug("acquired lock file {}".format(lockfile_path))


### PR DESCRIPTION
Current approach makes `r2e` create the lockfile under
`/tmp/rss2email.lock` if XDG_RUNTIME_DIR is unset, for all users,
making it impossible to use in shared shell environments. Instead,
create the lockfile under `/tmp/rss2email-${UID}/rss2email.lock`.

While there, document that XDG_RUNTIME_DIR is used for storing the
lockfile.