### PR TITLE
Run tests in development without subprocesses.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,4 +28,4 @@ jobs:
         pip install -r requirements.txt
     - name: Test
       run: |
-        ./test/test.py -v
+        ./test/test.py -v --subprocess

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,4 +28,4 @@ jobs:
         pip install -r requirements.txt
     - name: Test
       run: |
-        ./test/test.py -v --subprocess
+        ./runtests.sh -v --subprocess

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+args=()
+for arg in "$@"; do
+  case "$arg" in
+    --subprocess)
+      echo 'Running each invocation of r2e in a separate process...'
+      export SUBPROCESS=1
+      ;;
+    -s)
+      echo 'Not suppressing output...'
+      export NOCAPTURE=1
+      ;;
+    *)
+      args+=("$arg")
+      ;;
+  esac
+done
+
+if [ "$SUBPROCESS" = "1" ] && [ "$NOCAPTURE" = "1" ]; then
+  echo "-s and --subprocess flags are incompatible"
+  exit 1
+fi
+
+if [ "$SUBPROCESS" != "1" ]; then
+  echo "NOTE: Run with --subprocess flag for better test isolation."
+fi
+
+cd test || exit 1
+python -m unittest "${args[@]}"

--- a/test/README
+++ b/test/README
@@ -1,7 +1,6 @@
 Run tests with::
 
-  $ cd ./test
-  $ python -m unittest
+  $ ./runtests.sh
 
 … from the root of the project.
 
@@ -38,8 +37,15 @@ feed/config pair.  For example, with a directory structure like::
 * ``feed.rss`` after loading ``b.config`` and compare the output with
   ``b.expected``.
 
-Various other tests are also run, run test.py with the `-v`/`--verbose` option to
+Various other tests are also run, run runtests.sh with the `-v`/`--verbose` option to
 see exactly which tests are being run:
 
-  $ cd ./test
-  $ python -m unittest --verbose
+  $ ./runtests.sh --verbose
+
+Because the default test runner captures r2e output in order to make it's assertions, this output will not be printed to the console. This may be detrimental to your debugging efforts and makes it impossible to jump into rss2email code with pdb because stdout is suppressed. To pass output through to the console, use the `-s` flag:
+
+  $ ./runtests.sh -s
+
+By default the test runner will run r2e in the same process which is fast and makes debugging easier. However, in CI we run each r2e instance in a separate process for superior isolation. You can achieve this same quality with the `--subprocess` flag:
+
+  $ ./runtests.sh --subprocess

--- a/test/test.py
+++ b/test/test.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import List
 
 sys.path.insert(0, _os.path.dirname(__file__))
-from util.execcontext import r2e_path, ExecContext
+from util.execcontext import r2e_path, ExecContext, RunContext
 from util.tempmaildir import TemporaryMaildir
 
 # Directory containing test feed data/configs
@@ -432,4 +432,8 @@ class TestOPML(unittest.TestCase):
             self.assertEqual(content["feeds"][0]["name"], self.feed_name)
 
 if __name__ == '__main__':
+    if '--subprocess' in sys.argv:
+        sys.argv.remove('--subprocess')
+    else:
+        ExecContext = RunContext
     unittest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import List
 
 sys.path.insert(0, _os.path.dirname(__file__))
-from util.execcontext import r2e_path, ExecContext, RunContext
+from util.execcontext import r2e_path, ExecContext
 from util.tempmaildir import TemporaryMaildir
 
 # Directory containing test feed data/configs
@@ -432,11 +432,4 @@ class TestOPML(unittest.TestCase):
             self.assertEqual(content["feeds"][0]["name"], self.feed_name)
 
 if __name__ == '__main__':
-    if '--subprocess' in sys.argv:
-        sys.argv.remove('--subprocess')
-    else:
-        ExecContext = RunContext
-        if '-s' in sys.argv:
-            sys.argv.remove('-s')
-            RunContext.suppress = False
     unittest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -436,4 +436,7 @@ if __name__ == '__main__':
         sys.argv.remove('--subprocess')
     else:
         ExecContext = RunContext
+        if '-s' in sys.argv:
+            sys.argv.remove('-s')
+            RunContext.suppress = False
     unittest.main()

--- a/test/util/execcontext.py
+++ b/test/util/execcontext.py
@@ -65,7 +65,7 @@ def capture_output(suppress=True):
         rss2email.LOG.handlers[0].stream = sys.stderr
 
 
-class ExecContext:
+class ProcContext:
     """Creates temporary config, data file and lets you call r2e with them
     easily. Cleans up temp files afterwards.
 
@@ -106,9 +106,9 @@ class ExecContext:
             config.write(file)
 
 
-class RunContext(ExecContext):
+class RunContext(ProcContext):
     """ Run rss2email calls within the same python process. """
-    suppress = True
+    suppress = bool(os.getenv('NOCAPTURE') != '1')
 
     def call(self, *args):
         importlib.reload(rss2email.config)
@@ -124,3 +124,6 @@ class RunContext(ExecContext):
             stdout=output['stdout'],
             stderr=output['stderr'],
             returncode=0)
+
+
+ExecContext = ProcContext if os.getenv('SUBPROCESS') == '1' else RunContext

--- a/test/util/execcontext.py
+++ b/test/util/execcontext.py
@@ -18,20 +18,35 @@ sys.path.insert(0, os.path.dirname(r2e_path))
 import rss2email
 import rss2email.main
 
-
 # Mimic the subprocess.CompletedProcess api.
 ProcessStub = collections.namedtuple(
     'ProcessStub', ['stdout', 'stderr', 'returncode'])
 
 
+class TeeIO(io.TextIOWrapper):
+    def __init__(self, *args, tee=None):
+        self.tee = tee
+        super().__init__(*args)
+
+    def write(self, s):
+        self.tee.write(s)
+        return super().write(s)
+
+
 @contextlib.contextmanager
-def capture_output():
+def capture_output(suppress=True):
     # Adapted from: https://stackoverflow.com/a/64289688/1938621.
     output = {}
     try:
         # Redirect
-        sys.stdout = io.TextIOWrapper(io.BytesIO(), sys.stdout.encoding)
-        sys.stderr = io.TextIOWrapper(io.BytesIO(), sys.stderr.encoding)
+        if suppress:
+            sys.stdout = io.TextIOWrapper(io.BytesIO(), sys.stdout.encoding)
+            sys.stderr = io.TextIOWrapper(io.BytesIO(), sys.stderr.encoding)
+        else:
+            sys.stdout = TeeIO(
+                io.BytesIO(), sys.stdout.encoding, tee=sys.stdout)
+            sys.stderr = TeeIO(
+                io.BytesIO(), sys.stderr.encoding, tee=sys.stderr)
         assert len(rss2email.LOG.handlers) == 1
         rss2email.LOG.handlers[0].stream = sys.stderr
         yield output
@@ -93,12 +108,14 @@ class ExecContext:
 
 class RunContext(ExecContext):
     """ Run rss2email calls within the same python process. """
+    suppress = True
+
     def call(self, *args):
         importlib.reload(rss2email.config)
         rss2email.LOG.setLevel(
             rss2email.config.CONFIG['DEFAULT']['verbose'].upper())
 
-        with capture_output() as output:
+        with capture_output(suppress=self.suppress) as output:
             rss2email.main.run(
                 ["-c", str(self.cfg_path), "-d", str(self.data_path)] +
                 list(args))


### PR DESCRIPTION
This runs notably faster even with the small number of tests we
currently have and can make debugging easier in certain situations.

However I'd suggest we continue using subprocesses in CI for better
isolation. This will ensure that we don't accidentally introduce
inter-test state dependence which in my experience is a common cause of
false negative situations where tests don't actually test what they're
supposed to.