### PR TITLE
Add option to remove seen entries no longer in the feed.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,7 @@ UNRELEASED
       $XDG_DATA_HOME
     * Warnings about HTTP content-type being unexpected now properly display
     * Make the proxy parameter also affect https connections
+    * Add a --clean argument on the run command to reduce the database size
 
 v3.12.2 (2020-08-31)
     * Fix bug `AttributeError: 'NoneType' object has no attribute 'close'` (#126)

--- a/r2e.1
+++ b/r2e.1
@@ -67,7 +67,7 @@ optional \fI<email>\fR argument is the email address to send new items
 to, overriding the default address for this particular feed.  Repeat
 for each feed you want to subscribe to.
 .TP
-.B run \fR[\fI\-\-no-send\fR] \fR[\fI<index>\fR [\fI<index>\fR ...]]
+.B run \fR[\fI\-\-no-send\fR] \fR[\fI\-\-clean\fR] \fR[\fI<index>\fR [\fI<index>\fR ...]]
 Scan the feeds and send emails for new items. This can be run in a cron
 job.
 .P
@@ -75,6 +75,10 @@ job.
 The \-\-no-send option stops \fBr2e\fR from sending any email. This can be
 useful the first time you run it, as otherwise it would send an email
 for every available feed entry.
+.P
+The \-\-clean option reduces the database size by removing old entries. It
+forces a download of selected feeds or all feeds, and should only be used
+weekly or monthly.
 .P
 If an \fI<index>\fR is specified, \fBr2e\fR will only download that
 feed. \fI<index>\fR can be either the feed name (as set by \fBadd\fR)

--- a/rss2email/command.py
+++ b/rss2email/command.py
@@ -87,7 +87,7 @@ def run(feeds, args):
                             interval = interval
                         ))
                         _time.sleep(interval)
-                    feed.run(send=args.send)
+                    feed.run(send=args.send, clean=args.clean)
                 except _error.RSS2EmailError as e:
                     e.log()
                 last_server = current_server

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -898,7 +898,7 @@ class Feed (object):
             raise _error.NoToEmailAddress(feed=self)
         parsed = self._fetch()
 
-        if clean:
+        if clean and len(parsed.entries) > 0:
             for guid in self.seen:
                 self.seen[guid]['old'] = True
 
@@ -930,7 +930,7 @@ class Feed (object):
         self.etag = parsed.get('etag', None)
         self.modified = parsed.get('modified', None)
 
-        if clean:
+        if clean and len(parsed.entries) > 0:
             old = 3
             for guid in reversed(list(self.seen)):
                 if 'old' in self.seen[guid]:

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -896,6 +896,9 @@ class Feed (object):
         """
         if not self.to:
             raise _error.NoToEmailAddress(feed=self)
+        if clean:
+            self.etag = None
+            self.modified = None
         parsed = self._fetch()
 
         if clean and len(parsed.entries) > 0:

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -488,7 +488,8 @@ class Feed (object):
             new_state = {} # type: Dict[str, Any]
         else:
             _LOG.debug('already seen {}'.format(guid))
-            del self.seen[guid]['old']
+            if 'old' in old_state:
+                del old_state['old']
             if self.reply_changes:
                 if new_hash != old_state.get('hash'):
                     _LOG.debug('hash changed for {}'.format(guid))

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -930,9 +930,14 @@ class Feed (object):
         self.modified = parsed.get('modified', None)
 
         if clean:
-            for guid in list(self.seen):
+            old = 3
+            for guid in reversed(list(self.seen)):
                 if 'old' in self.seen[guid]:
-                    del self.seen[guid]
+                    if old > 0:
+                        del self.seen[guid]['old']
+                    else:
+                        del self.seen[guid]
+                    old = old - 1
 
     def _new_digest(self):
         digest = _MIMEMultipart('digest')

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -104,6 +104,9 @@ def run(*args, **kwargs):
         default=True, action='store_const', const=False,
         help="fetch feeds, but don't send email")
     run_parser.add_argument(
+        '--clean', action='store_true',
+        help='clean old feed entries')
+    run_parser.add_argument(
         'index', nargs='*',
         help='feeds to fetch (defaults to fetching all feeds)')
 


### PR DESCRIPTION
Using `r2e run --clean` will remove seen entries no longer found in the feed, avoiding the race-condition with `r2e reset ; r2e run -n`. This option could also be used instead of `r2e run` to keep the database small, or used periodically due to it being a little slower.

Some feeds only show the N most recent items and if a recent item is removed from the feed it will cause an older item to reappear, and r2e will resend it. The second patch keeps the 3 most recent old entries and should be enough to never resend an old item.

Should there be a short -C option, or another letter since it resembles -c?

Fixes #49 