### PR TITLE
Fix double escaping of sender names on certain configurations

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -51,6 +51,7 @@ from email.message import Message
 from email.mime.message import MIMEMessage as _MIMEMessage
 from email.mime.multipart import MIMEMultipart as _MIMEMultipart
 from email.utils import formataddr as _formataddr
+from email.utils import parseaddr as _parseaddr
 import hashlib as _hashlib
 import html.parser as _html_parser
 import re as _re
@@ -921,7 +922,7 @@ class Feed (object):
 
     def _new_digest(self):
         digest = _MIMEMultipart('digest')
-        digest['To'] = self.to  # TODO: _Header(), _formataddr((recipient_name, recipient_addr))
+        digest['To'] = _formataddr(_parseaddr(self.to))  # Encodes with utf-8 as necessary
         digest['Subject'] = 'digest for {}'.format(self.name)
         digest['Message-ID'] = '<{0}@{1}>'.format(_uuid.uuid4(), platform.node())
         digest['User-Agent'] = self.user_agent
@@ -942,7 +943,7 @@ class Feed (object):
         payload.  We assume that this part exists.  If you don't have
         any messages in the digest, don't call this function.
         """
-        digest['From'] = sender  # TODO: _Header(), _formataddr()...
+        digest['From'] = sender
         last_part = digest.get_payload()[-1]
         last_message = last_part.get_payload()[0]
         digest['Date'] = last_message['Date']

--- a/test/data/bbc-chinese/3.config
+++ b/test/data/bbc-chinese/3.config
@@ -1,0 +1,4 @@
+[DEFAULT]
+to = a@b.com
+date-header = True
+encodings = UTF-8

--- a/test/data/bbc-chinese/3.expected
+++ b/test/data/bbc-chinese/3.expected
@@ -1,0 +1,46 @@
+SENT BY: =?utf-8?b?YmJjY2hpbmVzZS5jb20gfCDkuLvpobU6IEJCQyBDaGluZXNl?= <chinese@bbc.co.uk>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: base64
+From: =?utf-8?b?YmJjY2hpbmVzZS5jb20gfCDkuLvpobU6IEJCQyBDaGluZXNl?= <chinese@bbc.co.uk>
+To: a@b.com
+Subject: =?utf-8?b?5Zu96ZmF6LSn5biB5Z+66YeR57uE57uH56ew5YWo55CD57uP5rWO5oGi5aSN5pS+57yT?=
+Date: Wed, 23 Jan 2013 20:50:57 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/bbc-chinese/feed.atom
+X-RSS-ID: tag:www.bbcchinese.com,2013-01-23:22535346
+X-RSS-URL: http://www.bbc.co.uk/zhongwen/simp/world/2013/01/130123_imf_world_economy.shtml
+X-RSS-TAGS: =?utf-8?b?Y2hpbmVzZV9zaW1wbGlmaWVkLHdvcmxkLOS4lueVjOmTtuihjO+8jCDmiqXlkYrvvIwg57uP5rWO5Y+R5bGV?=
+
+5Zu96ZmF6LSn5biB5Z+66YeR57uE57uH77yISU1G77yJ6K2m5ZGK6K+077yM5bC9566h5ZCE5Zu9
+5pS/5bqc6YeH5Y+W5o6q5pa95Yi65r+A57uP5rWO77yM5L2G5YWo55CD57uP5rWO5oGi5aSN6YCf
+5bqm5q2j5Zyo5YeP5byx44CCCgpVUkw6IGh0dHA6Ly93d3cuYmJjLmNvLnVrL3pob25nd2VuL3Np
+bXAvd29ybGQvMjAxMy8wMS8xMzAxMjNfaW1mX3dvcmxkX2Vjb25vbXkuc2h0bWw=
+
+
+SENT BY: =?utf-8?b?YmJjY2hpbmVzZS5jb20gfCDkuLvpobU6IEJCQyBDaGluZXNl?= <chinese@bbc.co.uk>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: base64
+From: =?utf-8?b?YmJjY2hpbmVzZS5jb20gfCDkuLvpobU6IEJCQyBDaGluZXNl?= <chinese@bbc.co.uk>
+To: a@b.com
+Subject: =?utf-8?b?55m95a6r5o+Q5ZCN6Im+5Lym5Li65YyX57qm5pyA6auY5Y+45Luk5a6Y?=
+Date: Wed, 23 Jan 2013 20:55:42 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/bbc-chinese/feed.atom
+X-RSS-ID: tag:www.bbcchinese.com,2013-01-23:22535477
+X-RSS-URL: http://www.bbc.co.uk/zhongwen/simp/world/2013/01/130123_us_genallen_nato.shtml
+X-RSS-TAGS: =?utf-8?b?Y2hpbmVzZV9zaW1wbGlmaWVkLHdvcmxkLOe+juWbve+8jOWMl+e6pu+8jOWbvemYsumDqO+8jOmpu+mYv+WvjOaxl+e+juWGm+WPuOS7pOWumO+8jOS4reWkruaDheaKpeWxgO+8jOWpmuWkluaDhQ==?=
+
+576O5Zu955m95a6r56ew77yM5bCG5o+Q5ZCN6am76Zi/5a+M5rGX576O5Yab5Y+45Luk5a6Y57qm
+57+w4oCn6Im+5Lym5Li65YyX57qm5pyA6auY5Y+45Luk5a6Y44CC6Im+5Lym5pu+5Zug5Y+X5oyH
+56ew5ZCM5LiA5aWz5oCn5pyJ4oCc5LiN5b2T4oCd6YKu5Lu25p2l5b6A6ICM6KKr6LCD5p+l44CC
+CgpVUkw6IGh0dHA6Ly93d3cuYmJjLmNvLnVrL3pob25nd2VuL3NpbXAvd29ybGQvMjAxMy8wMS8x
+MzAxMjNfdXNfZ2VuYWxsZW5fbmF0by5zaHRtbA==
+


### PR DESCRIPTION
Before this patch, if the sender name included non-ASCII characters, and 'US-ASCII' was not the first in the user-configurable list of encodings, then the sender name would be doubly escaped, and the MUA would dutifully display an unfriendly From: =?utf-8?b?…?= <…@…> (see full explanation in the commit message). The fix is to let `formataddr` do its job and not to re-process its result.

The included new test case demonstrates nicely how the badly-encoded message looks like, when run with the old code.