### PR TITLE
Set HTML attribute dir=auto on body element

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ UNRELEASED
     * Warnings about HTTP content-type being unexpected now properly display
     * Make the proxy parameter also affect https connections
     * Add a --clean argument on the run command to reduce the database size
+    * Set body element attribute dir=auto in HTML mail
 
 v3.12.2 (2020-08-31)
     * Fix bug `AttributeError: 'NoneType' object has no attribute 'close'` (#126)

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -810,7 +810,7 @@ class Feed (object):
                         ])
             lines.extend([
                     '</head>',
-                    '<body>',
+                    '<body dir="auto">',
                     '<div id="entry">',
                     '<h1 class="header"><a href="{}">{}</a></h1>'.format(
                         _saxutils.escape(link), _saxutils.escape(subject)),

--- a/test/data/gmane/3.expected
+++ b/test/data/gmane/3.expected
@@ -18,7 +18,7 @@ X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/1
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="http://permalink.gmane.org/gmane.mail.rss2email/1">Re: new maintainer and mailing list for rss2email</a></h1>
 <div id="body">
@@ -80,7 +80,7 @@ X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/2
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="http://permalink.gmane.org/gmane.mail.rss2email/2">Re: new maintainer and mailing list for rss2email</a></h1>
 <div id="body">
@@ -132,7 +132,7 @@ X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/3
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="http://permalink.gmane.org/gmane.mail.rss2email/3">Re: new maintainer and mailing list for rss2email</a></h1>
 <div id="body">
@@ -168,7 +168,7 @@ X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/4
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="http://permalink.gmane.org/gmane.mail.rss2email/4">Re: new maintainer and mailing list for rss2email</a></h1>
 <div id="body">
@@ -207,7 +207,7 @@ X-RSS-URL: http://permalink.gmane.org/gmane.mail.rss2email/5
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="http://permalink.gmane.org/gmane.mail.rss2email/5">split massive package into modules</a></h1>
 <div id="body">

--- a/test/data/gmane/4.expected
+++ b/test/data/gmane/4.expected
@@ -23,7 +23,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="http://permalink.gmane.org/gmane.mail.rss2email/1">Re: new maintainer and mailing list for rss2email</a></h1>
 <div id="body">
@@ -136,7 +136,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="http://permalink.gmane.org/gmane.mail.rss2email/2">Re: new maintainer and mailing list for rss2email</a></h1>
 <div id="body">
@@ -229,7 +229,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="http://permalink.gmane.org/gmane.mail.rss2email/3">Re: new maintainer and mailing list for rss2email</a></h1>
 <div id="body">
@@ -289,7 +289,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="http://permalink.gmane.org/gmane.mail.rss2email/4">Re: new maintainer and mailing list for rss2email</a></h1>
 <div id="body">
@@ -356,7 +356,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="http://permalink.gmane.org/gmane.mail.rss2email/5">split massive package into modules</a></h1>
 <div id="body">

--- a/test/data/quiltville/1.expected
+++ b/test/data/quiltville/1.expected
@@ -18,7 +18,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/02/projects-in-holding-pattern.h
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/02/pro=
 jects-in-holding-pattern.html">Projects in a Holding Pattern -</a></h1>
@@ -102,7 +102,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/02/speaking-of-labels-and-more.h
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/02/spe=
 aking-of-labels-and-more.html">Speaking of Labels and More....</a></h1>
@@ -178,7 +178,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/02/into-rainy-weekend.html
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/02/int=
 o-rainy-weekend.html">Into a Rainy Weekend -</a></h1>
@@ -251,7 +251,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/rough-tumble-into-march.html
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/rou=
 gh-tumble-into-march.html">Rough &amp; Tumble into March!</a></h1>
@@ -309,7 +309,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/more-blue-in-studio.html
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/mor=
 e-blue-in-studio.html">MORE Blue in the Studio!</a></h1>
@@ -377,7 +377,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/small-studio-changes-big-stud
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/sma=
 ll-studio-changes-big-studio-impact.html">Small Studio Changes, Big Studio =
@@ -457,7 +457,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/monas-in-studio.html
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/mon=
 as-in-studio.html">Mona's in the Studio!</a></h1>
@@ -530,7 +530,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/quilting-from-sunrise-to-suns
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/qui=
 lting-from-sunrise-to-sunset.html">Quilting from Sunrise to Sunset -</a></h=
@@ -617,7 +617,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/goodbye-hello.html
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/goo=
 dbye-hello.html">Goodbye, Hello!</a></h1>
@@ -695,7 +695,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/diamond-tiles-on-day-three.ht
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/dia=
 mond-tiles-on-day-three.html">Diamond Tiles on Day Three!</a></h1>
@@ -774,60 +774,60 @@ X-RSS-Feed: data/quiltville/feed.atom
 X-RSS-ID: tag:blogger.com,1999:blog-13569819.post-3583285823339513514
 X-RSS-URL: https://quiltville.blogspot.com/2021/03/its-here-bonnie-k-hunters-quilters-tech.html
 
-PCFET0NUWVBFIGh0bWw+CjxodG1sPgogIDxoZWFkPgo8L2hlYWQ+Cjxib2R5Pgo8ZGl2IGlkPSJl
-bnRyeSI+CjxoMSBjbGFzcz0iaGVhZGVyIj48YSBocmVmPSJodHRwczovL3F1aWx0dmlsbGUuYmxv
-Z3Nwb3QuY29tLzIwMjEvMDMvaXRzLWhlcmUtYm9ubmllLWstaHVudGVycy1xdWlsdGVycy10ZWNo
-Lmh0bWwiPkl0J3MgSGVyZSEgQm9ubmllIEsuIEh1bnRlcidzIFF1aWx0ZXIncyBUZWNoIFNldCE8
-L2E+PC9oMT4KPGRpdiBpZD0iYm9keSI+CjxkaXYgY2xhc3M9InNlcGFyYXRvciIgc3R5bGU9ImNs
-ZWFyOiBib3RoOyB0ZXh0LWFsaWduOiBjZW50ZXI7Ij48YSBocmVmPSJodHRwczovLzEuYnAuYmxv
-Z3Nwb3QuY29tLy1oMDFMSW1iYmFNYy9ZRWRvT0tRc05ESS9BQUFBQUFBSkxmUS9Wa0pSUGd6a0pa
-d1Y2WXlHdXNWNDNvamdiUGt1Ym5kQ0FDTGNCR0FzWUhRL3MxMDI0LzIwMjEwMzA4XzE1MjI0Mi5q
-cGciIHN0eWxlPSJtYXJnaW4tbGVmdDogMWVtOyBtYXJnaW4tcmlnaHQ6IDFlbTsiPjxzcGFuIHN0
-eWxlPSJjb2xvcjogYmxhY2s7IGZvbnQtZmFtaWx5OiBpbmhlcml0OyBmb250LXNpemU6IG1lZGl1
-bTsiPjxpbWcgYm9yZGVyPSIwIiBoZWlnaHQ9IjQ5MCIgc3JjPSJodHRwczovLzEuYnAuYmxvZ3Nw
-b3QuY29tLy1oMDFMSW1iYmFNYy9ZRWRvT0tRc05ESS9BQUFBQUFBSkxmUS9Wa0pSUGd6a0pad1Y2
-WXlHdXNWNDNvamdiUGt1Ym5kQ0FDTGNCR0FzWUhRL3c2NDAtaDQ5MC8yMDIxMDMwOF8xNTIyNDIu
-anBnIiB3aWR0aD0iNjQwIiAvPjwvc3Bhbj48L2E+PC9kaXY+PHNwYW4gc3R5bGU9ImZvbnQtZmFt
-aWx5OiBpbmhlcml0OyBmb250LXNpemU6IG1lZGl1bTsiPjxiciAvPjwvc3Bhbj48ZGl2IGNsYXNz
-PSJzZXBhcmF0b3IiIHN0eWxlPSJjbGVhcjogYm90aDsgdGV4dC1hbGlnbjogbGVmdDsiPjxwIHN0
-eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiB3aGl0ZTsgcGFkZGluZzogMHB4OyI+PHNwYW4gc3R5bGU9
-ImZvbnQtZmFtaWx5OiBpbmhlcml0OyBmb250LXNpemU6IG1lZGl1bTsiPlNvbWUgZnVuIHRoaW5n
-cyBoYXZlIGJlZW4gbG9uZyBpbiB0aGUgJnF1b3Q7YmVoaW5kIHRoZSBzY2VuZXMmcXVvdDsgY29s
-dW1uLCBwbGF5aW5nIHRoZSB3YWl0aW5nIGdhbWUgdG8gZ2V0IHRoaW5ncyBtYW51ZmFjdHVyZWQg
-YW5kIHJlbGVhc2VkIC0gaXQncyBiZWVuIHRoYXQgd2hvbGUgc3VwcGx5IGNoYWluIGJhY2sgdXAs
-IHlvdSBrbm93Pzwvc3Bhbj48L3A+PHAgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6IHdoaXRlOyBw
-YWRkaW5nOiAwcHg7Ij48c3BhbiBzdHlsZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6
-ZTogbWVkaXVtOyI+SSB3YXMgd2FpdGluZyBmb3IgdGhlc2UgdG8gYmUgcmVhZHkgZm9yIHRoZSBo
-b2xpZGF5IHNlYXNvbiAtIGJlY2F1c2UgdGhleSBtYWtlIHN1Y2ggR1JFQVQgZ2lmdHMhwqAgQnV0
-IE1hcmNoIGlzIGdvb2QgdG9vITwvc3Bhbj48L3A+PHAgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6
-IHdoaXRlOyBwYWRkaW5nOiAwcHg7Ij48c3BhbiBzdHlsZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7
-IGZvbnQtc2l6ZTogbWVkaXVtOyI+VGhlc2UgYXJlIHRoaW5ncyBJIHVzZSBFVkVSWSBEQVkgaW4g
-bXkgdHJhdmVsIGxpZmUgYXMgd2VsbCBhcyBteSBwZXJzb25hbCBsaWZlIOKAkyBhbmQgSSBrbm93
-IHlvdSBhcmUgZ29pbmcgdG8gbG92ZSB0aGVtIGFzIG11Y2ggYXMgSSBkby48L3NwYW4+PC9wPjxw
-IHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiB3aGl0ZTsgcGFkZGluZzogMHB4OyI+PHNwYW4gc3R5
-bGU9ImZvbnQtZmFtaWx5OiBpbmhlcml0OyBmb250LXNpemU6IG1lZGl1bTsiPkkgaGF2ZSB3b3Ju
-IGdsYXNzZXMgc2luY2UgSSB3YXMgMyB5ZWFycyBvbGQg4oCTIHNvbWV0aGluZyBJIGRvbuKAmXQg
-b2Z0ZW4gaGF2ZSB0aGUgY2hhbmNlIHRvIGFkbWl0LCBhbmQgd2hpbGUgSSBoYXRlZCBiZWluZyBj
-YWxsZWQg4oCcZm91ciBleWVz4oCdIGluIHNjaG9vbCwgYW5kIHN3aXRjaGVkIHRvIGNvbnRhY3Rz
-IGluIGhpZ2ggc2Nob29sIChvaCB0aGUgdmFuaXR5LCBhbmQgZGVzaXJlIHRvIGZpdCBpbiEpIEkg
-Z2F2ZSB1cCBvbiB0aGF0IGluIGNvbGxlZ2UgYW5kIGhhdmUgaGFkIGdsYXNzZXMgcGVyY2hlZCBv
-biB0b3Agb2YgbXkgbm9zZSBhbGwgZGF5LCBldmVyeSBkYXkgc2luY2UhPC9zcGFuPjwvcD48cCBz
-dHlsZT0iYmFja2dyb3VuZC1jb2xvcjogd2hpdGU7IHBhZGRpbmc6IDBweDsiPjxzcGFuIHN0eWxl
-PSJmb250LWZhbWlseTogaW5oZXJpdDsgZm9udC1zaXplOiBtZWRpdW07Ij5Ob3cgdGhhdCBJIGhh
-dmUgcmVhY2hlZCB0aGUg4oCcbWlkZGxlIGFnZeKAnSB6b25lIOKAkyBJ4oCZbSBmaW5kaW5nIHRo
-YXQgZ2xhc3NlcyB3ZWFyaW5nIGlzIG1vcmUgdGhlIG5vcm0gZm9yIG5lYXJseSBldmVyeW9uZSDi
-gJMgd2hldGhlciB0aGV5IHVzZSBzaW1wbGUgcmVhZGVycyB0byBzZWUgY2xvc2VyIHdoZW4gc3Rp
-dGNoaW5nIG9yIHdoaWxlIHdvcmtpbmcgYXQgdGhlIGNvbXB1dGVyLCBvciB0aG9zZSBvZiB1cyB3
-aG8gbmVlZCBvdXIgZ2xhc3NlcyBldmVyeSBkYXksIGFuZCBhcmUgZ3JhdGVmdWwgZm9yIHRoZSBh
-YmlsaXR5IHRvIHNlZSB3aGF0IHdlIGFyZSBkb2luZywgd2hhdGV2ZXIgd2UgYXJlIGRvaW5nLCBt
-b3JlIGNsZWFybHkuPHNwYW4+PC9zcGFuPjwvc3Bhbj48L3A+PC9kaXY+PGEgaHJlZj0iaHR0cHM6
-Ly9xdWlsdHZpbGxlLmJsb2dzcG90LmNvbS8yMDIxLzAzL2l0cy1oZXJlLWJvbm5pZS1rLWh1bnRl
-cnMtcXVpbHRlcnMtdGVjaC5odG1sI21vcmUiPkRpZCBZb3UgQ2xpY2sgdG8gUmVhZCB0aGUgV2hv
-bGUgU3Rvcnk/PC9hPgo8L2Rpdj4KPGRpdiBjbGFzcz0iZm9vdGVyIj48cD5VUkw6IDxhIGhyZWY9
-Imh0dHBzOi8vcXVpbHR2aWxsZS5ibG9nc3BvdC5jb20vMjAyMS8wMy9pdHMtaGVyZS1ib25uaWUt
-ay1odW50ZXJzLXF1aWx0ZXJzLXRlY2guaHRtbCI+aHR0cHM6Ly9xdWlsdHZpbGxlLmJsb2dzcG90
-LmNvbS8yMDIxLzAzL2l0cy1oZXJlLWJvbm5pZS1rLWh1bnRlcnMtcXVpbHRlcnMtdGVjaC5odG1s
-PC9hPjwvcD4KPC9kaXY+CjwvZGl2Pgo8L2JvZHk+CjwvaHRtbD4K
+PCFET0NUWVBFIGh0bWw+CjxodG1sPgogIDxoZWFkPgo8L2hlYWQ+Cjxib2R5IGRpcj0iYXV0byI+
+CjxkaXYgaWQ9ImVudHJ5Ij4KPGgxIGNsYXNzPSJoZWFkZXIiPjxhIGhyZWY9Imh0dHBzOi8vcXVp
+bHR2aWxsZS5ibG9nc3BvdC5jb20vMjAyMS8wMy9pdHMtaGVyZS1ib25uaWUtay1odW50ZXJzLXF1
+aWx0ZXJzLXRlY2guaHRtbCI+SXQncyBIZXJlISBCb25uaWUgSy4gSHVudGVyJ3MgUXVpbHRlcidz
+IFRlY2ggU2V0ITwvYT48L2gxPgo8ZGl2IGlkPSJib2R5Ij4KPGRpdiBjbGFzcz0ic2VwYXJhdG9y
+IiBzdHlsZT0iY2xlYXI6IGJvdGg7IHRleHQtYWxpZ246IGNlbnRlcjsiPjxhIGhyZWY9Imh0dHBz
+Oi8vMS5icC5ibG9nc3BvdC5jb20vLWgwMUxJbWJiYU1jL1lFZG9PS1FzTkRJL0FBQUFBQUFKTGZR
+L1ZrSlJQZ3prSlp3VjZZeUd1c1Y0M29qZ2JQa3VibmRDQUNMY0JHQXNZSFEvczEwMjQvMjAyMTAz
+MDhfMTUyMjQyLmpwZyIgc3R5bGU9Im1hcmdpbi1sZWZ0OiAxZW07IG1hcmdpbi1yaWdodDogMWVt
+OyI+PHNwYW4gc3R5bGU9ImNvbG9yOiBibGFjazsgZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQt
+c2l6ZTogbWVkaXVtOyI+PGltZyBib3JkZXI9IjAiIGhlaWdodD0iNDkwIiBzcmM9Imh0dHBzOi8v
+MS5icC5ibG9nc3BvdC5jb20vLWgwMUxJbWJiYU1jL1lFZG9PS1FzTkRJL0FBQUFBQUFKTGZRL1Zr
+SlJQZ3prSlp3VjZZeUd1c1Y0M29qZ2JQa3VibmRDQUNMY0JHQXNZSFEvdzY0MC1oNDkwLzIwMjEw
+MzA4XzE1MjI0Mi5qcGciIHdpZHRoPSI2NDAiIC8+PC9zcGFuPjwvYT48L2Rpdj48c3BhbiBzdHls
+ZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6ZTogbWVkaXVtOyI+PGJyIC8+PC9zcGFu
+PjxkaXYgY2xhc3M9InNlcGFyYXRvciIgc3R5bGU9ImNsZWFyOiBib3RoOyB0ZXh0LWFsaWduOiBs
+ZWZ0OyI+PHAgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6IHdoaXRlOyBwYWRkaW5nOiAwcHg7Ij48
+c3BhbiBzdHlsZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6ZTogbWVkaXVtOyI+U29t
+ZSBmdW4gdGhpbmdzIGhhdmUgYmVlbiBsb25nIGluIHRoZSAmcXVvdDtiZWhpbmQgdGhlIHNjZW5l
+cyZxdW90OyBjb2x1bW4sIHBsYXlpbmcgdGhlIHdhaXRpbmcgZ2FtZSB0byBnZXQgdGhpbmdzIG1h
+bnVmYWN0dXJlZCBhbmQgcmVsZWFzZWQgLSBpdCdzIGJlZW4gdGhhdCB3aG9sZSBzdXBwbHkgY2hh
+aW4gYmFjayB1cCwgeW91IGtub3c/PC9zcGFuPjwvcD48cCBzdHlsZT0iYmFja2dyb3VuZC1jb2xv
+cjogd2hpdGU7IHBhZGRpbmc6IDBweDsiPjxzcGFuIHN0eWxlPSJmb250LWZhbWlseTogaW5oZXJp
+dDsgZm9udC1zaXplOiBtZWRpdW07Ij5JIHdhcyB3YWl0aW5nIGZvciB0aGVzZSB0byBiZSByZWFk
+eSBmb3IgdGhlIGhvbGlkYXkgc2Vhc29uIC0gYmVjYXVzZSB0aGV5IG1ha2Ugc3VjaCBHUkVBVCBn
+aWZ0cyHCoCBCdXQgTWFyY2ggaXMgZ29vZCB0b28hPC9zcGFuPjwvcD48cCBzdHlsZT0iYmFja2dy
+b3VuZC1jb2xvcjogd2hpdGU7IHBhZGRpbmc6IDBweDsiPjxzcGFuIHN0eWxlPSJmb250LWZhbWls
+eTogaW5oZXJpdDsgZm9udC1zaXplOiBtZWRpdW07Ij5UaGVzZSBhcmUgdGhpbmdzIEkgdXNlIEVW
+RVJZIERBWSBpbiBteSB0cmF2ZWwgbGlmZSBhcyB3ZWxsIGFzIG15IHBlcnNvbmFsIGxpZmUg4oCT
+IGFuZCBJIGtub3cgeW91IGFyZSBnb2luZyB0byBsb3ZlIHRoZW0gYXMgbXVjaCBhcyBJIGRvLjwv
+c3Bhbj48L3A+PHAgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6IHdoaXRlOyBwYWRkaW5nOiAwcHg7
+Ij48c3BhbiBzdHlsZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6ZTogbWVkaXVtOyI+
+SSBoYXZlIHdvcm4gZ2xhc3NlcyBzaW5jZSBJIHdhcyAzIHllYXJzIG9sZCDigJMgc29tZXRoaW5n
+IEkgZG9u4oCZdCBvZnRlbiBoYXZlIHRoZSBjaGFuY2UgdG8gYWRtaXQsIGFuZCB3aGlsZSBJIGhh
+dGVkIGJlaW5nIGNhbGxlZCDigJxmb3VyIGV5ZXPigJ0gaW4gc2Nob29sLCBhbmQgc3dpdGNoZWQg
+dG8gY29udGFjdHMgaW4gaGlnaCBzY2hvb2wgKG9oIHRoZSB2YW5pdHksIGFuZCBkZXNpcmUgdG8g
+Zml0IGluISkgSSBnYXZlIHVwIG9uIHRoYXQgaW4gY29sbGVnZSBhbmQgaGF2ZSBoYWQgZ2xhc3Nl
+cyBwZXJjaGVkIG9uIHRvcCBvZiBteSBub3NlIGFsbCBkYXksIGV2ZXJ5IGRheSBzaW5jZSE8L3Nw
+YW4+PC9wPjxwIHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiB3aGl0ZTsgcGFkZGluZzogMHB4OyI+
+PHNwYW4gc3R5bGU9ImZvbnQtZmFtaWx5OiBpbmhlcml0OyBmb250LXNpemU6IG1lZGl1bTsiPk5v
+dyB0aGF0IEkgaGF2ZSByZWFjaGVkIHRoZSDigJxtaWRkbGUgYWdl4oCdIHpvbmUg4oCTIEnigJlt
+IGZpbmRpbmcgdGhhdCBnbGFzc2VzIHdlYXJpbmcgaXMgbW9yZSB0aGUgbm9ybSBmb3IgbmVhcmx5
+IGV2ZXJ5b25lIOKAkyB3aGV0aGVyIHRoZXkgdXNlIHNpbXBsZSByZWFkZXJzIHRvIHNlZSBjbG9z
+ZXIgd2hlbiBzdGl0Y2hpbmcgb3Igd2hpbGUgd29ya2luZyBhdCB0aGUgY29tcHV0ZXIsIG9yIHRo
+b3NlIG9mIHVzIHdobyBuZWVkIG91ciBnbGFzc2VzIGV2ZXJ5IGRheSwgYW5kIGFyZSBncmF0ZWZ1
+bCBmb3IgdGhlIGFiaWxpdHkgdG8gc2VlIHdoYXQgd2UgYXJlIGRvaW5nLCB3aGF0ZXZlciB3ZSBh
+cmUgZG9pbmcsIG1vcmUgY2xlYXJseS48c3Bhbj48L3NwYW4+PC9zcGFuPjwvcD48L2Rpdj48YSBo
+cmVmPSJodHRwczovL3F1aWx0dmlsbGUuYmxvZ3Nwb3QuY29tLzIwMjEvMDMvaXRzLWhlcmUtYm9u
+bmllLWstaHVudGVycy1xdWlsdGVycy10ZWNoLmh0bWwjbW9yZSI+RGlkIFlvdSBDbGljayB0byBS
+ZWFkIHRoZSBXaG9sZSBTdG9yeT88L2E+CjwvZGl2Pgo8ZGl2IGNsYXNzPSJmb290ZXIiPjxwPlVS
+TDogPGEgaHJlZj0iaHR0cHM6Ly9xdWlsdHZpbGxlLmJsb2dzcG90LmNvbS8yMDIxLzAzL2l0cy1o
+ZXJlLWJvbm5pZS1rLWh1bnRlcnMtcXVpbHRlcnMtdGVjaC5odG1sIj5odHRwczovL3F1aWx0dmls
+bGUuYmxvZ3Nwb3QuY29tLzIwMjEvMDMvaXRzLWhlcmUtYm9ubmllLWstaHVudGVycy1xdWlsdGVy
+cy10ZWNoLmh0bWw8L2E+PC9wPgo8L2Rpdj4KPC9kaXY+CjwvYm9keT4KPC9odG1sPgo=
 
 
 SENT BY: "Quiltville's Quips & Snips!!: Bonnie K. Hunter" <noreply@blogger.com>
@@ -850,7 +850,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/first-road-hike-day.html
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/fir=
 st-road-hike-day.html">Sewing and Road Hiking!</a></h1>
@@ -922,7 +922,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/red-birthday-tractors-for-win
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/red=
 -birthday-tractors-for-win.html">Red Birthday Tractors for the Win!</a></h1>
@@ -997,7 +997,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/up-on-roof-singing.html
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/up-=
 on-roof-singing.html">Up On The Roof.... *singing*</a></h1>
@@ -1065,7 +1065,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/quilt-me-river.html
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/qui=
 lt-me-river.html">Quilt Me A River ...</a></h1>
@@ -1135,7 +1135,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/tulip-time-pattern-time-and-g
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/tul=
 ip-time-pattern-time-and-gift-away.html">Tulip Time Pattern Time (and Gift-=
@@ -1204,7 +1204,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/the-rush-to-beat-rain.html
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/the=
 -rush-to-beat-rain.html">The Rush to Beat the Rain.</a></h1>
@@ -1275,7 +1275,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/hike-little-sew-little-more.h
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/hik=
 e-little-sew-little-more.html">Hike a Little, Sew a Little More!</a></h1>
@@ -1345,7 +1345,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/misty-mornings-and-coming-of-
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/mis=
 ty-mornings-and-coming-of-green.html">Misty Mornings and the Coming of the =
@@ -1414,7 +1414,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/antique-mall-on-loose.html
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/ant=
 ique-mall-on-loose.html">Antique Mall - On the Loose!</a></h1>
@@ -1497,7 +1497,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/with-bit-of-courage-faith-joy
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://quiltville.blogspot.com/2021/03/with-bit-of-courage-faith-joy.html">With a bit of Courage, Faith &amp; Joy!</a></h1>
 <div id="body">
@@ -1526,72 +1526,72 @@ X-RSS-Feed: data/quiltville/feed.atom
 X-RSS-ID: tag:blogger.com,1999:blog-13569819.post-2809753183118597774
 X-RSS-URL: https://quiltville.blogspot.com/2021/03/blockbase-gift-away.html
 
-PCFET0NUWVBFIGh0bWw+CjxodG1sPgogIDxoZWFkPgo8L2hlYWQ+Cjxib2R5Pgo8ZGl2IGlkPSJl
-bnRyeSI+CjxoMSBjbGFzcz0iaGVhZGVyIj48YSBocmVmPSJodHRwczovL3F1aWx0dmlsbGUuYmxv
-Z3Nwb3QuY29tLzIwMjEvMDMvYmxvY2tiYXNlLWdpZnQtYXdheS5odG1sIj5CbG9ja0Jhc2UrIEdp
-ZnQtQXdheSE8L2E+PC9oMT4KPGRpdiBpZD0iYm9keSI+CjxkaXYgY2xhc3M9InNlcGFyYXRvciIg
-c3R5bGU9ImNsZWFyOiBib3RoOyB0ZXh0LWFsaWduOiBjZW50ZXI7Ij48c3BhbiBzdHlsZT0iZm9u
-dC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6ZTogbWVkaXVtOyI+PGJyIC8+PC9zcGFuPjwvZGl2
-PjxkaXYgY2xhc3M9InNlcGFyYXRvciIgc3R5bGU9ImNsZWFyOiBib3RoOyB0ZXh0LWFsaWduOiBj
-ZW50ZXI7Ij48YSBocmVmPSJodHRwczovLzEuYnAuYmxvZ3Nwb3QuY29tLy1KX0dvOURZZzYwRS9Z
-Rmg4d2NkUTl0SS9BQUFBQUFBSk5Vcy9QSjJTWlZFTW1wZ000RVZsb0EwZnFvWDRYX21Na3AzZXdD
-TGNCR0FzWUhRL3M4MDAvSU1HXzIwMjEwMzIyXzA3MTMzM181MDMwMDAuanBnIiBzdHlsZT0ibWFy
-Z2luLWxlZnQ6IDFlbTsgbWFyZ2luLXJpZ2h0OiAxZW07Ij48c3BhbiBzdHlsZT0iY29sb3I6IGJs
-YWNrOyBmb250LWZhbWlseTogaW5oZXJpdDsgZm9udC1zaXplOiBtZWRpdW07Ij48aW1nIGJvcmRl
-cj0iMCIgaGVpZ2h0PSI2NDAiIHNyYz0iaHR0cHM6Ly8xLmJwLmJsb2dzcG90LmNvbS8tSl9HbzlE
-WWc2MEUvWUZoOHdjZFE5dEkvQUFBQUFBQUpOVXMvUEoyU1pWRU1tcGdNNEVWbG9BMGZxb1g0WF9t
-TWtwM2V3Q0xjQkdBc1lIUS93NjQwLWg2NDAvSU1HXzIwMjEwMzIyXzA3MTMzM181MDMwMDAuanBn
-IiB3aWR0aD0iNjQwIiAvPjwvc3Bhbj48L2E+PC9kaXY+PHNwYW4gc3R5bGU9ImZvbnQtZmFtaWx5
-OiBpbmhlcml0OyBmb250LXNpemU6IG1lZGl1bTsiPjxiciAvPjwvc3Bhbj48ZGl2IGNsYXNzPSJz
-ZXBhcmF0b3IiIHN0eWxlPSJjbGVhcjogYm90aDsgdGV4dC1hbGlnbjogbGVmdDsiPjxkaXY+PHNw
-YW4gc3R5bGU9ImZvbnQtZmFtaWx5OiBpbmhlcml0OyBmb250LXNpemU6IG1lZGl1bTsiPjxzcGFu
-IHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiB3aGl0ZTsiPkhhdmUgeW91IGhlYXJkIG9mIHRoZSBu
-ZXcgQmxvY2tCYXNlKyBiecKgPC9zcGFuPjxzcGFuIHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiAj
-Y2ZlMmYzOyI+PGEgaHJlZj0iaHR0cHM6Ly9lbGVjdHJpY3F1aWx0LmNvbS8iIHRhcmdldD0iX2Js
-YW5rIj5UaGUgRWxlY3RyaWMgUXVpbHQgQ29tcGFueTwvYT48L3NwYW4+PHNwYW4gc3R5bGU9ImJh
-Y2tncm91bmQtY29sb3I6IHdoaXRlOyI+ID8/PC9zcGFuPjwvc3Bhbj48L2Rpdj48ZGl2IHN0eWxl
-PSJiYWNrZ3JvdW5kLWNvbG9yOiB3aGl0ZTsiPjxzcGFuIHN0eWxlPSJmb250LWZhbWlseTogaW5o
-ZXJpdDsgZm9udC1zaXplOiBtZWRpdW07Ij48YnIgLz48L3NwYW4+PC9kaXY+PHNwYW4gc3R5bGU9
-ImJhY2tncm91bmQtY29sb3I6IHdoaXRlOyBmb250LWZhbWlseTogaW5oZXJpdDsgZm9udC1zaXpl
-OiBtZWRpdW07Ij5JIGFtIHNvIGV4Y2l0ZWQgYWJvdXQgdGhlIE5FVyBCbG9ja0Jhc2UrIEkgY2Fu
-IGhhcmRseSBjb250YWluIG15c2VsZi7CoDwvc3Bhbj48ZGl2IHN0eWxlPSJiYWNrZ3JvdW5kLWNv
-bG9yOiB3aGl0ZTsiPjxzcGFuIHN0eWxlPSJmb250LWZhbWlseTogaW5oZXJpdDsgZm9udC1zaXpl
-OiBtZWRpdW07Ij48YnIgLz48L3NwYW4+PC9kaXY+PGRpdiBzdHlsZT0iYmFja2dyb3VuZC1jb2xv
-cjogd2hpdGU7Ij48c3BhbiBzdHlsZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6ZTog
-bWVkaXVtOyI+SSBoYXZlIGJlZW4gYW4gRVEgdXNlciBmcm9tIHRoZSB2ZXJ5IGZpcnN0IHJlbGVh
-c2UuIEkgb3duIHRoZSBwcmV2aW91cyB2ZXJzaW9uIG9mIEJsb2NrQmFzZSwgcnVubmluZyBpdCB3
-aXRoIG15IGRpZmZlcmVudCBFUSB2ZXJzaW9ucyBhbGwgdGhlIHdheSB1cCB0aHJvdWdoIEVRNy7C
-oDwvc3Bhbj48L2Rpdj48ZGl2IHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiB3aGl0ZTsiPjxzcGFu
+PCFET0NUWVBFIGh0bWw+CjxodG1sPgogIDxoZWFkPgo8L2hlYWQ+Cjxib2R5IGRpcj0iYXV0byI+
+CjxkaXYgaWQ9ImVudHJ5Ij4KPGgxIGNsYXNzPSJoZWFkZXIiPjxhIGhyZWY9Imh0dHBzOi8vcXVp
+bHR2aWxsZS5ibG9nc3BvdC5jb20vMjAyMS8wMy9ibG9ja2Jhc2UtZ2lmdC1hd2F5Lmh0bWwiPkJs
+b2NrQmFzZSsgR2lmdC1Bd2F5ITwvYT48L2gxPgo8ZGl2IGlkPSJib2R5Ij4KPGRpdiBjbGFzcz0i
+c2VwYXJhdG9yIiBzdHlsZT0iY2xlYXI6IGJvdGg7IHRleHQtYWxpZ246IGNlbnRlcjsiPjxzcGFu
 IHN0eWxlPSJmb250LWZhbWlseTogaW5oZXJpdDsgZm9udC1zaXplOiBtZWRpdW07Ij48YnIgLz48
-L3NwYW4+PC9kaXY+PGRpdiBzdHlsZT0iYmFja2dyb3VuZC1jb2xvcjogd2hpdGU7Ij48c3BhbiBz
-dHlsZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6ZTogbWVkaXVtOyI+SSBsb3ZlIHRo
-YXQgdGhlcmUgaXMgYSBuZXcsIHVwZGF0ZWQgdmVyc2lvbiB0byBnbyBhbG9uZyB3aXRoIG15IEVR
-OCBzb2Z0d2FyZS7CoDwvc3Bhbj48L2Rpdj48ZGl2IHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiB3
-aGl0ZTsiPjxzcGFuIHN0eWxlPSJmb250LWZhbWlseTogaW5oZXJpdDsgZm9udC1zaXplOiBtZWRp
-dW07Ij48YnIgLz48L3NwYW4+PC9kaXY+PGRpdiBzdHlsZT0iYmFja2dyb3VuZC1jb2xvcjogd2hp
-dGU7Ij48c3BhbiBzdHlsZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6ZTogbWVkaXVt
-OyI+TXkgZmF2b3JpdGUgdGhpbmc/IFBhaXJpbmcgdHdvIGJsb2NrcyB0b2dldGhlciB0byBzZWUg
-d2hhdCBvdGhlciBpbnRlcmVzdGluZyBzZWNvbmRhcnkgZGVzaWducyBoYXBwZW4gYmV0d2VlbiB0
-aGUgYmxvY2tzLiBJdOKAmXMgbWFnaWMhwqA8L3NwYW4+PC9kaXY+PGRpdiBzdHlsZT0iYmFja2dy
-b3VuZC1jb2xvcjogd2hpdGU7Ij48c3BhbiBzdHlsZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZv
-bnQtc2l6ZTogbWVkaXVtOyI+PGJyIC8+PC9zcGFuPjwvZGl2PjxkaXYgc3R5bGU9ImJhY2tncm91
+L3NwYW4+PC9kaXY+PGRpdiBjbGFzcz0ic2VwYXJhdG9yIiBzdHlsZT0iY2xlYXI6IGJvdGg7IHRl
+eHQtYWxpZ246IGNlbnRlcjsiPjxhIGhyZWY9Imh0dHBzOi8vMS5icC5ibG9nc3BvdC5jb20vLUpf
+R285RFlnNjBFL1lGaDh3Y2RROXRJL0FBQUFBQUFKTlVzL1BKMlNaVkVNbXBnTTRFVmxvQTBmcW9Y
+NFhfbU1rcDNld0NMY0JHQXNZSFEvczgwMC9JTUdfMjAyMTAzMjJfMDcxMzMzXzUwMzAwMC5qcGci
+IHN0eWxlPSJtYXJnaW4tbGVmdDogMWVtOyBtYXJnaW4tcmlnaHQ6IDFlbTsiPjxzcGFuIHN0eWxl
+PSJjb2xvcjogYmxhY2s7IGZvbnQtZmFtaWx5OiBpbmhlcml0OyBmb250LXNpemU6IG1lZGl1bTsi
+PjxpbWcgYm9yZGVyPSIwIiBoZWlnaHQ9IjY0MCIgc3JjPSJodHRwczovLzEuYnAuYmxvZ3Nwb3Qu
+Y29tLy1KX0dvOURZZzYwRS9ZRmg4d2NkUTl0SS9BQUFBQUFBSk5Vcy9QSjJTWlZFTW1wZ000RVZs
+b0EwZnFvWDRYX21Na3AzZXdDTGNCR0FzWUhRL3c2NDAtaDY0MC9JTUdfMjAyMTAzMjJfMDcxMzMz
+XzUwMzAwMC5qcGciIHdpZHRoPSI2NDAiIC8+PC9zcGFuPjwvYT48L2Rpdj48c3BhbiBzdHlsZT0i
+Zm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6ZTogbWVkaXVtOyI+PGJyIC8+PC9zcGFuPjxk
+aXYgY2xhc3M9InNlcGFyYXRvciIgc3R5bGU9ImNsZWFyOiBib3RoOyB0ZXh0LWFsaWduOiBsZWZ0
+OyI+PGRpdj48c3BhbiBzdHlsZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6ZTogbWVk
+aXVtOyI+PHNwYW4gc3R5bGU9ImJhY2tncm91bmQtY29sb3I6IHdoaXRlOyI+SGF2ZSB5b3UgaGVh
+cmQgb2YgdGhlIG5ldyBCbG9ja0Jhc2UrIGJ5wqA8L3NwYW4+PHNwYW4gc3R5bGU9ImJhY2tncm91
+bmQtY29sb3I6ICNjZmUyZjM7Ij48YSBocmVmPSJodHRwczovL2VsZWN0cmljcXVpbHQuY29tLyIg
+dGFyZ2V0PSJfYmxhbmsiPlRoZSBFbGVjdHJpYyBRdWlsdCBDb21wYW55PC9hPjwvc3Bhbj48c3Bh
+biBzdHlsZT0iYmFja2dyb3VuZC1jb2xvcjogd2hpdGU7Ij4gPz88L3NwYW4+PC9zcGFuPjwvZGl2
+PjxkaXYgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6IHdoaXRlOyI+PHNwYW4gc3R5bGU9ImZvbnQt
+ZmFtaWx5OiBpbmhlcml0OyBmb250LXNpemU6IG1lZGl1bTsiPjxiciAvPjwvc3Bhbj48L2Rpdj48
+c3BhbiBzdHlsZT0iYmFja2dyb3VuZC1jb2xvcjogd2hpdGU7IGZvbnQtZmFtaWx5OiBpbmhlcml0
+OyBmb250LXNpemU6IG1lZGl1bTsiPkkgYW0gc28gZXhjaXRlZCBhYm91dCB0aGUgTkVXIEJsb2Nr
+QmFzZSsgSSBjYW4gaGFyZGx5IGNvbnRhaW4gbXlzZWxmLsKgPC9zcGFuPjxkaXYgc3R5bGU9ImJh
+Y2tncm91bmQtY29sb3I6IHdoaXRlOyI+PHNwYW4gc3R5bGU9ImZvbnQtZmFtaWx5OiBpbmhlcml0
+OyBmb250LXNpemU6IG1lZGl1bTsiPjxiciAvPjwvc3Bhbj48L2Rpdj48ZGl2IHN0eWxlPSJiYWNr
+Z3JvdW5kLWNvbG9yOiB3aGl0ZTsiPjxzcGFuIHN0eWxlPSJmb250LWZhbWlseTogaW5oZXJpdDsg
+Zm9udC1zaXplOiBtZWRpdW07Ij5JIGhhdmUgYmVlbiBhbiBFUSB1c2VyIGZyb20gdGhlIHZlcnkg
+Zmlyc3QgcmVsZWFzZS4gSSBvd24gdGhlIHByZXZpb3VzIHZlcnNpb24gb2YgQmxvY2tCYXNlLCBy
+dW5uaW5nIGl0IHdpdGggbXkgZGlmZmVyZW50IEVRIHZlcnNpb25zIGFsbCB0aGUgd2F5IHVwIHRo
+cm91Z2ggRVE3LsKgPC9zcGFuPjwvZGl2PjxkaXYgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6IHdo
+aXRlOyI+PHNwYW4gc3R5bGU9ImZvbnQtZmFtaWx5OiBpbmhlcml0OyBmb250LXNpemU6IG1lZGl1
+bTsiPjxiciAvPjwvc3Bhbj48L2Rpdj48ZGl2IHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiB3aGl0
+ZTsiPjxzcGFuIHN0eWxlPSJmb250LWZhbWlseTogaW5oZXJpdDsgZm9udC1zaXplOiBtZWRpdW07
+Ij5JIGxvdmUgdGhhdCB0aGVyZSBpcyBhIG5ldywgdXBkYXRlZCB2ZXJzaW9uIHRvIGdvIGFsb25n
+IHdpdGggbXkgRVE4IHNvZnR3YXJlLsKgPC9zcGFuPjwvZGl2PjxkaXYgc3R5bGU9ImJhY2tncm91
 bmQtY29sb3I6IHdoaXRlOyI+PHNwYW4gc3R5bGU9ImZvbnQtZmFtaWx5OiBpbmhlcml0OyBmb250
-LXNpemU6IG1lZGl1bTsiPlRoZSBvbmx5IHRoaW5nIGJldHRlciB0aGFuIHRoZSBORVcgRW5jeWNs
-b3BlZGlhIG9mIFBpZWNlZCBRdWlsdCBQYXR0ZXJucyBib29rIOKAkyBpcyB0aGUgYWJpbGl0eSB0
-byBoYXZlIHRob3NlIGJsb2NrcyBpbiBCbG9ja0Jhc2UrLCB0byBnbyB3aXRoIG15IEVROCE8L3Nw
-YW4+PC9kaXY+PGRpdiBzdHlsZT0iYmFja2dyb3VuZC1jb2xvcjogd2hpdGU7Ij48c3BhbiBzdHls
-ZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6ZTogbWVkaXVtOyI+PGJyIC8+PC9zcGFu
-PjwvZGl2PjxkaXYgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6IHdoaXRlOyI+PHNwYW4gc3R5bGU9
-ImZvbnQtZmFtaWx5OiBpbmhlcml0OyBmb250LXNpemU6IG1lZGl1bTsiPk5vdyBmb3IgdGhlIGZ1
-biBwYXJ0IC0gRWxlY3RyaWMgUXVpbHQgaXMgR0lWSU5HIEFXQVkgYSBmcmVlIEJsb2NrIEJhc2Ug
-UGx1cyBmb3Igb25lIGx1Y2t5IHBlcnNvbiB3aG8gZW50ZXJzIG9uIHRvZGF5J3MgYmxvZyBwb3N0
-ISBJdCBjb3VsZCBiZSB5b3UhPHNwYW4+PC9zcGFuPjwvc3Bhbj48L2Rpdj48L2Rpdj48YSBocmVm
-PSJodHRwczovL3F1aWx0dmlsbGUuYmxvZ3Nwb3QuY29tLzIwMjEvMDMvYmxvY2tiYXNlLWdpZnQt
-YXdheS5odG1sI21vcmUiPkRpZCBZb3UgQ2xpY2sgdG8gUmVhZCB0aGUgV2hvbGUgU3Rvcnk/PC9h
-Pgo8L2Rpdj4KPGRpdiBjbGFzcz0iZm9vdGVyIj48cD5VUkw6IDxhIGhyZWY9Imh0dHBzOi8vcXVp
-bHR2aWxsZS5ibG9nc3BvdC5jb20vMjAyMS8wMy9ibG9ja2Jhc2UtZ2lmdC1hd2F5Lmh0bWwiPmh0
-dHBzOi8vcXVpbHR2aWxsZS5ibG9nc3BvdC5jb20vMjAyMS8wMy9ibG9ja2Jhc2UtZ2lmdC1hd2F5
-Lmh0bWw8L2E+PC9wPgo8L2Rpdj4KPC9kaXY+CjwvYm9keT4KPC9odG1sPgo=
+LXNpemU6IG1lZGl1bTsiPjxiciAvPjwvc3Bhbj48L2Rpdj48ZGl2IHN0eWxlPSJiYWNrZ3JvdW5k
+LWNvbG9yOiB3aGl0ZTsiPjxzcGFuIHN0eWxlPSJmb250LWZhbWlseTogaW5oZXJpdDsgZm9udC1z
+aXplOiBtZWRpdW07Ij5NeSBmYXZvcml0ZSB0aGluZz8gUGFpcmluZyB0d28gYmxvY2tzIHRvZ2V0
+aGVyIHRvIHNlZSB3aGF0IG90aGVyIGludGVyZXN0aW5nIHNlY29uZGFyeSBkZXNpZ25zIGhhcHBl
+biBiZXR3ZWVuIHRoZSBibG9ja3MuIEl04oCZcyBtYWdpYyHCoDwvc3Bhbj48L2Rpdj48ZGl2IHN0
+eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiB3aGl0ZTsiPjxzcGFuIHN0eWxlPSJmb250LWZhbWlseTog
+aW5oZXJpdDsgZm9udC1zaXplOiBtZWRpdW07Ij48YnIgLz48L3NwYW4+PC9kaXY+PGRpdiBzdHls
+ZT0iYmFja2dyb3VuZC1jb2xvcjogd2hpdGU7Ij48c3BhbiBzdHlsZT0iZm9udC1mYW1pbHk6IGlu
+aGVyaXQ7IGZvbnQtc2l6ZTogbWVkaXVtOyI+VGhlIG9ubHkgdGhpbmcgYmV0dGVyIHRoYW4gdGhl
+IE5FVyBFbmN5Y2xvcGVkaWEgb2YgUGllY2VkIFF1aWx0IFBhdHRlcm5zIGJvb2sg4oCTIGlzIHRo
+ZSBhYmlsaXR5IHRvIGhhdmUgdGhvc2UgYmxvY2tzIGluIEJsb2NrQmFzZSssIHRvIGdvIHdpdGgg
+bXkgRVE4ITwvc3Bhbj48L2Rpdj48ZGl2IHN0eWxlPSJiYWNrZ3JvdW5kLWNvbG9yOiB3aGl0ZTsi
+PjxzcGFuIHN0eWxlPSJmb250LWZhbWlseTogaW5oZXJpdDsgZm9udC1zaXplOiBtZWRpdW07Ij48
+YnIgLz48L3NwYW4+PC9kaXY+PGRpdiBzdHlsZT0iYmFja2dyb3VuZC1jb2xvcjogd2hpdGU7Ij48
+c3BhbiBzdHlsZT0iZm9udC1mYW1pbHk6IGluaGVyaXQ7IGZvbnQtc2l6ZTogbWVkaXVtOyI+Tm93
+IGZvciB0aGUgZnVuIHBhcnQgLSBFbGVjdHJpYyBRdWlsdCBpcyBHSVZJTkcgQVdBWSBhIGZyZWUg
+QmxvY2sgQmFzZSBQbHVzIGZvciBvbmUgbHVja3kgcGVyc29uIHdobyBlbnRlcnMgb24gdG9kYXkn
+cyBibG9nIHBvc3QhIEl0IGNvdWxkIGJlIHlvdSE8c3Bhbj48L3NwYW4+PC9zcGFuPjwvZGl2Pjwv
+ZGl2PjxhIGhyZWY9Imh0dHBzOi8vcXVpbHR2aWxsZS5ibG9nc3BvdC5jb20vMjAyMS8wMy9ibG9j
+a2Jhc2UtZ2lmdC1hd2F5Lmh0bWwjbW9yZSI+RGlkIFlvdSBDbGljayB0byBSZWFkIHRoZSBXaG9s
+ZSBTdG9yeT88L2E+CjwvZGl2Pgo8ZGl2IGNsYXNzPSJmb290ZXIiPjxwPlVSTDogPGEgaHJlZj0i
+aHR0cHM6Ly9xdWlsdHZpbGxlLmJsb2dzcG90LmNvbS8yMDIxLzAzL2Jsb2NrYmFzZS1naWZ0LWF3
+YXkuaHRtbCI+aHR0cHM6Ly9xdWlsdHZpbGxlLmJsb2dzcG90LmNvbS8yMDIxLzAzL2Jsb2NrYmFz
+ZS1naWZ0LWF3YXkuaHRtbDwvYT48L3A+CjwvZGl2Pgo8L2Rpdj4KPC9ib2R5Pgo8L2h0bWw+Cg==
 
 
 SENT BY: "Quiltville's Quips & Snips!!: Bonnie K. Hunter" <noreply@blogger.com>
@@ -1614,7 +1614,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/weekend-trail-warriors.html
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/wee=
 kend-trail-warriors.html">Weekend Trail Warriors!</a></h1>
@@ -1682,7 +1682,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/rivanna-runner-bound-done.htm
 <html>
   <head>
 </head>
-<body>
+<body dir=3D"auto">
 <div id=3D"entry">
 <h1 class=3D"header"><a href=3D"https://quiltville.blogspot.com/2021/03/riv=
 anna-runner-bound-done.html">Rivanna Runner Bound - DONE!</a></h1>
@@ -1754,7 +1754,7 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/bloom-baby-bloom.html
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://quiltville.blogspot.com/2021/03/bloom-baby-bloom.html">Bloom, Baby, Bloom!</a></h1>
 <div id="body">

--- a/test/data/tails/2.expected
+++ b/test/data/tails/2.expected
@@ -24,7 +24,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://tails.boum.org/news/version_4.8/index.en.html">Tails 4.8 is out</a></h1>
 <div id="body">
@@ -338,7 +338,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://tails.boum.org/news/version_4.9/index.en.html">Tails 4.9 is out</a></h1>
 <div id="body">
@@ -545,7 +545,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://tails.boum.org/news/version_4.10/index.en.html">Tails 4.10 is out</a></h1>
 <div id="body">
@@ -751,7 +751,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://tails.boum.org/news/test_4.11-rc1/">Call for testing: 4.11~rc1</a></h1>
 <div id="body">
@@ -1000,7 +1000,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://tails.boum.org/news/version_4.11/index.en.html">Tails 4.11 is out</a></h1>
 <div id="body">
@@ -1223,7 +1223,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://tails.boum.org/news/version_4.12/index.en.html">Tails 4.12 is out</a></h1>
 <div id="body">
@@ -1434,7 +1434,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://tails.boum.org/news/version_4.13/index.en.html">Tails 4.13 is out</a></h1>
 <div id="body">
@@ -1654,7 +1654,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://tails.boum.org/news/verification_extension_deprecation/index.en.html">Deprecation of the Tails Verification extension</a></h1>
 <div id="body">
@@ -1789,7 +1789,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://tails.boum.org/news/version_4.14/index.en.html">Tails 4.14 is out</a></h1>
 <div id="body">
@@ -2029,7 +2029,7 @@ Content-Transfer-Encoding: 7bit
 <html>
   <head>
 </head>
-<body>
+<body dir="auto">
 <div id="entry">
 <h1 class="header"><a href="https://tails.boum.org/news/achievements_in_2020/index.en.html">Our achievements in 2020</a></h1>
 <div id="body">


### PR DESCRIPTION
Has no effect on non-RTL text, or on feed items that have their `dir` attribute already set properly, but can help greatly with reading RTL items that neglect to specify the `dir` attribute.

See [the spec](https://html.spec.whatwg.org/multipage/dom.html#the-dir-attribute) for some hard-core technicalities, or scroll down to the example there for a visual demonstration.

I am opening this as a draft PR to gather comments, but will wait with rebasing until #174 is decided because of conflicting changes.