### PR TITLE
Add r2e script to the poetry section in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,6 @@ update-copyright = ">=0.6.2"
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"
+
+[tool.poetry.scripts]
+r2e = "rss2email.main:run"


### PR DESCRIPTION
Pip installation from VCS might ignore setup.py in favour of pyproject.toml,
hence the need for duplication.