### PR TITLE
Fix feedparser status check regression on Python>=3.9

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -28,4 +28,5 @@ jobs:
         poetry install
     - name: Test
       run: |
-        poetry run ./test/test.py -v
+        cd ./test
+        poetry run python -m unittest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -404,9 +404,12 @@ class Feed (object):
 
     def _check_for_errors(self, parsed):
         warned = False
-        status = getattr(parsed, 'status', 200)
+        status = getattr(parsed, 'status', None)
         _LOG.debug('HTTP status {}'.format(status))
-        if status == 301:
+        if status is None:
+            # On non-HTTP schemes, like file://
+            pass
+        elif status == 301:
             _LOG.info('redirect {} from {} to {}'.format(
                     self.name, self.url, parsed['url']))
             self.url = parsed['url']


### PR DESCRIPTION
Fixes #178.

Instead of waiting for kurtmckee/feedparser#272 to be resolved and then updating our requirement from `feedparser>=6.0.0` to the fixed version, I chose to support the already-released versions of feedparser by accepting `None` as a valid status.