### PR TITLE
Add fetch option to add command

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,8 @@ v3.13 (2021-04-03)
     * Add a --clean argument on the run command to reduce the database size
     * Set body element attribute dir=auto in HTML mail
     * Store the lock file in XDG_RUNTIME_DIR instead of /tmp
+    * New argument `--only-new` on the `add` command to ignore entries in feed
+      when added, so only new entries will be sent.
 
 v3.12.3 (2021-03-19)
     * Make dependency on feedparser have an upper bound so that `pip install`

--- a/r2e.1
+++ b/r2e.1
@@ -60,12 +60,17 @@ sets the default email address that mails are sent to.
 .B email \fR[\fI<email>\fR]
 Update the default target email address to \fI<email>\fR.
 .TP
-.B add \fI<name>\fR \fI<url>\fR [\fI<email>\fR]
+.B add \fR[\fI\-\-only-new\fR] \fI<name>\fR \fI<url>\fR [\fI<email>\fR]
 Subscribe to a feed. The \fI<name>\fR argument gives the feed a name
 for future manipulation. \fI<url>\fR is the URL of the feed.  The
 optional \fI<email>\fR argument is the email address to send new items
 to, overriding the default address for this particular feed.  Repeat
 for each feed you want to subscribe to.
+.P
+.RS 4
+The \-\-only-new option will prevent entries already in the feed to be
+sent.
+.RE
 .TP
 .B run \fR[\fI\-\-no-send\fR] \fR[\fI\-\-clean\fR] \fR[\fI<index>\fR [\fI<index>\fR ...]]
 Scan the feeds and send emails for new items. This can be run in a cron

--- a/r2e.1
+++ b/r2e.1
@@ -68,8 +68,11 @@ to, overriding the default address for this particular feed.  Repeat
 for each feed you want to subscribe to.
 .P
 .RS 4
-The \-\-only-new option will prevent entries already in the feed to be
-sent.
+The \-\-only-new option fetches the feed at addition time without
+sending the entries, making subsequent \fBrun\fR execution consider
+them as already having been sent. It should be used when one is only
+interested in entries that are not yet in the feed at the time of
+running \fBadd\fR.
 .RE
 .TP
 .B run \fR[\fI\-\-no-send\fR] \fR[\fI\-\-clean\fR] \fR[\fI<index>\fR [\fI<index>\fR ...]]

--- a/rss2email/command.py
+++ b/rss2email/command.py
@@ -61,6 +61,8 @@ def add(feeds, args):
     _LOG.info('add new feed {}'.format(feed))
     if not feed.to:
         raise _error.NoToEmailAddress(feed=feed, feeds=feeds)
+    if args.only_new:
+        feed.run(send=False, clean=False)
     feeds.save()
 
 def run(feeds, args):

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -101,7 +101,7 @@ def run(*args, **kwargs):
     add_parser.add_argument(
         '--only-new', dest='only_new',
         default=False, action='store_const', const=True,
-        help="entries in the feed now will be not sent")
+        help="entries in the feed now will not be sent")
 
     run_parser = subparsers.add_parser(
         'run', help=_command.run.__doc__.splitlines()[0])

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -99,8 +99,7 @@ def run(*args, **kwargs):
         'email', nargs='?',
         help='target email for the new feed')
     add_parser.add_argument(
-        '--only-new', dest='only_new',
-        default=False, action='store_const', const=True,
+        '--only-new', action='store_true',
         help="entries in the feed now will not be sent")
 
     run_parser = subparsers.add_parser(

--- a/rss2email/main.py
+++ b/rss2email/main.py
@@ -98,6 +98,10 @@ def run(*args, **kwargs):
     add_parser.add_argument(
         'email', nargs='?',
         help='target email for the new feed')
+    add_parser.add_argument(
+        '--only-new', dest='only_new',
+        default=False, action='store_const', const=True,
+        help="entries in the feed now will be not sent")
 
     run_parser = subparsers.add_parser(
         'run', help=_command.run.__doc__.splitlines()[0])

--- a/test/test.py
+++ b/test/test.py
@@ -193,7 +193,7 @@ def webserver_for_test_fetch(queue, num_requests, wait_time):
         httpd.server_close()
 
 def webserver_for_test_if_fetch(queue, timeout):
-    """Span a webserver for `timeout` seconds"""
+    """Spawn a webserver for `timeout` seconds"""
     httpd = http.server.HTTPServer(('', 0), NoLogHandler)
     httpd.timeout = timeout
     try:


### PR DESCRIPTION
Hi,
i've added a new option to the `add` command:  `--fetch` (short `-f`), to fetch/initialize a feed while adding.

The as-is alternative is a `add` and a `run --no-send` risking losing any other updates.