### PR TITLE
Fix crash on html-mail entries with no URL

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 UNRELEASED
+    * Fix crash on html-mail entries with no URL
 
 v3.13 (2021-04-03)
     * Switch to feedparser 6

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -818,7 +818,8 @@ class Feed (object):
                     '<body dir="auto">',
                     '<div id="entry">',
                     '<h1 class="header"><a href="{}">{}</a></h1>'.format(
-                        _saxutils.escape(link), _saxutils.escape(subject)),
+                        _saxutils.escape(link) if link else '',
+                        _saxutils.escape(subject)),
                     '<div id="body">',
                     ])
             if content['type'] in ('text/html', 'application/xhtml+xml'):
@@ -826,10 +827,11 @@ class Feed (object):
             else:
                 lines.append(_saxutils.escape(content['value'].strip()))
             lines.append('</div>')
-            lines.extend([
-                    '<div class="footer">',
-                    '<p>URL: <a href="{0}">{0}</a></p>'.format(_saxutils.escape(link)),
-                    ])
+            lines.append('<div class="footer">')
+            if link:
+                lines.append(
+                    '<p>URL: <a href="{0}">{0}</a></p>'.format(
+                        _saxutils.escape(link)))
             for enclosure in getattr(entry, 'enclosures', []):
                 if getattr(enclosure, 'url', None):
                     lines.append(

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -827,7 +827,7 @@ class Feed (object):
                 lines.append(_saxutils.escape(content['value'].strip()))
             lines.append('</div>')
             lines.extend([
-                    '<div class="footer">'
+                    '<div class="footer">',
                     '<p>URL: <a href="{0}">{0}</a></p>'.format(_saxutils.escape(link)),
                     ])
             for enclosure in getattr(entry, 'enclosures', []):

--- a/test/data/fastmailstatus/1.config
+++ b/test/data/fastmailstatus/1.config
@@ -1,0 +1,4 @@
+[DEFAULT]
+to = a@b.com
+date-header = True
+html-mail = True

--- a/test/data/fastmailstatus/1.expected
+++ b/test/data/fastmailstatus/1.expected
@@ -1,0 +1,319 @@
+SENT BY: "Fastmail Status: <author>" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "Fastmail Status: <author>" <user@rss2email.invalid>
+To: a@b.com
+Subject: General availability - Warning
+Date: Tue, 26 Jan 2021 18:35:15 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/fastmailstatus/feed.rss
+X-RSS-ID: 3BBE2C00-6005-11EB-9AA1-A5E048FE9AF7
+
+<!DOCTYPE html>
+<html>
+  <head>
+</head>
+<body dir="auto">
+<div id="entry">
+<h1 class="header"><a href="">General availability - Warning</a></h1>
+<div id="body">
+A small segment of customers are experiencing interrupted access to Fastmail services. We're looking into it.
+</div>
+<div class="footer">
+</div>
+</div>
+</body>
+</html>
+
+
+SENT BY: "Fastmail Status: <author>" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "Fastmail Status: <author>" <user@rss2email.invalid>
+To: a@b.com
+Subject: General availability - Up
+Date: Tue, 26 Jan 2021 20:54:10 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/fastmailstatus/feed.rss
+X-RSS-ID: A3AE9CEC-6018-11EB-9AA1-A5E048FE9AF7
+
+<!DOCTYPE html>
+<html>
+  <head>
+</head>
+<body dir="auto">
+<div id="entry">
+<h1 class="header"><a href="">General availability - Up</a></h1>
+<div id="body">
+We've resolved the issue and access has been restored. No mail has been lost.
+</div>
+<div class="footer">
+</div>
+</div>
+</body>
+</html>
+
+
+SENT BY: "Fastmail Status: <author>" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "Fastmail Status: <author>" <user@rss2email.invalid>
+To: a@b.com
+Subject: Support System - Warning
+Date: Tue, 09 Mar 2021 03:59:37 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/fastmailstatus/feed.rss
+X-RSS-ID: DDE8438E-808B-11EB-A9D6-823F50FE9AF7
+
+<!DOCTYPE html>
+<html>
+  <head>
+</head>
+<body dir="auto">
+<div id="entry">
+<h1 class="header"><a href="">Support System - Warning</a></h1>
+<div id="body">
+Our customer support system is currently performing a scheduled upgrade expected to last two to three hours. During this time, our support team will not be responding to requests. Tickets emailed to support@fastmail.com will be delayed, but not lost.
+</div>
+<div class="footer">
+</div>
+</div>
+</body>
+</html>
+
+
+SENT BY: "Fastmail Status: <author>" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "Fastmail Status: <author>" <user@rss2email.invalid>
+To: a@b.com
+Subject: Support System - Up
+Date: Tue, 09 Mar 2021 05:09:40 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/fastmailstatus/feed.rss
+X-RSS-ID: A73D84DE-8095-11EB-A9D6-823F50FE9AF7
+
+<!DOCTYPE html>
+<html>
+  <head>
+</head>
+<body dir="auto">
+<div id="entry">
+<h1 class="header"><a href="">Support System - Up</a></h1>
+<div id="body">
+The scheduled upgrade to our customer support system is complete. No tickets were lost. Thanks for your patience!
+</div>
+<div class="footer">
+</div>
+</div>
+</body>
+</html>
+
+
+SENT BY: "Fastmail Status: <author>" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "Fastmail Status: <author>" <user@rss2email.invalid>
+To: a@b.com
+Subject: Support System - Down
+Date: Fri, 19 Mar 2021 01:49:49 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/fastmailstatus/feed.rss
+X-RSS-ID: 63DB21E8-8855-11EB-A9D6-823F50FE9AF7
+
+<!DOCTYPE html>
+<html>
+  <head>
+</head>
+<body dir="auto">
+<div id="entry">
+<h1 class="header"><a href="">Support System - Down</a></h1>
+<div id="body">
+Our customer support system will experience a brief downtime expected to last 10 to 30 minutes. During this time, our support team will not be responding to requests.  Tickets emailed to support@fastmail.com will be delayed, but not lost.
+</div>
+<div class="footer">
+</div>
+</div>
+</body>
+</html>
+
+
+SENT BY: "Fastmail Status: <author>" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "Fastmail Status: <author>" <user@rss2email.invalid>
+To: a@b.com
+Subject: Support System - Up
+Date: Fri, 19 Mar 2021 02:30:46 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/fastmailstatus/feed.rss
+X-RSS-ID: 1C464866-885B-11EB-A9D6-823F50FE9AF7
+
+<!DOCTYPE html>
+<html>
+  <head>
+</head>
+<body dir="auto">
+<div id="entry">
+<h1 class="header"><a href="">Support System - Up</a></h1>
+<div id="body">
+Access to the customer support system has been restored, and we're ready to assist you!
+</div>
+<div class="footer">
+</div>
+</div>
+</body>
+</html>
+
+
+SENT BY: "Fastmail Status: <author>" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "Fastmail Status: <author>" <user@rss2email.invalid>
+To: a@b.com
+Subject: Support System - Down
+Date: Fri, 19 Mar 2021 20:04:20 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/fastmailstatus/feed.rss
+X-RSS-ID: 4ADB3D56-88EE-11EB-A9D6-823F50FE9AF7
+
+<!DOCTYPE html>
+<html>
+  <head>
+</head>
+<body dir="auto">
+<div id="entry">
+<h1 class="header"><a href="">Support System - Down</a></h1>
+<div id="body">
+Our customer support system will experience a brief downtime expected to last 10 to 30 minutes. During this time, our support team will not be responding to requests. Tickets emailed to support@fastmail.com will be delayed, but not lost.
+</div>
+<div class="footer">
+</div>
+</div>
+</body>
+</html>
+
+
+SENT BY: "Fastmail Status: <author>" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "Fastmail Status: <author>" <user@rss2email.invalid>
+To: a@b.com
+Subject: Support System - Up
+Date: Fri, 19 Mar 2021 20:37:08 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/fastmailstatus/feed.rss
+X-RSS-ID: E017F5EA-88F2-11EB-A9D6-823F50FE9AF7
+
+<!DOCTYPE html>
+<html>
+  <head>
+</head>
+<body dir="auto">
+<div id="entry">
+<h1 class="header"><a href="">Support System - Up</a></h1>
+<div id="body">
+Access to the customer support system has been restored, and we're ready to assist you!
+</div>
+<div class="footer">
+</div>
+</div>
+</body>
+</html>
+
+
+SENT BY: "Fastmail Status: <author>" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "Fastmail Status: <author>" <user@rss2email.invalid>
+To: a@b.com
+Subject: Login & sessions - Warning
+Date: Tue, 20 Apr 2021 01:44:49 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/fastmailstatus/feed.rss
+X-RSS-ID: FE688B1E-A179-11EB-8CC4-B51653FE9AF7
+
+<!DOCTYPE html>
+<html>
+  <head>
+</head>
+<body dir="auto">
+<div id="entry">
+<h1 class="header"><a href="">Login &amp; sessions - Warning</a></h1>
+<div id="body">
+Customers are currently unable to log out. We've isolated the cause and expect it will be resolved within an hour.
+</div>
+<div class="footer">
+</div>
+</div>
+</body>
+</html>
+
+
+SENT BY: "Fastmail Status: <author>" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "Fastmail Status: <author>" <user@rss2email.invalid>
+To: a@b.com
+Subject: Login & sessions - Up
+Date: Tue, 20 Apr 2021 02:43:26 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/fastmailstatus/feed.rss
+X-RSS-ID: 2EC9D062-A182-11EB-8CC4-B51653FE9AF7
+
+<!DOCTYPE html>
+<html>
+  <head>
+</head>
+<body dir="auto">
+<div id="entry">
+<h1 class="header"><a href="">Login &amp; sessions - Up</a></h1>
+<div id="body">
+We've resolved the issue and the ability to log out has been restored. No mail has been lost.
+</div>
+<div class="footer">
+</div>
+</div>
+</body>
+</html>
+

--- a/test/data/fastmailstatus/README
+++ b/test/data/fastmailstatus/README
@@ -1,0 +1,15 @@
+feed.rss is a snapshot of
+
+  https://www.fastmailstatus.com/feed
+
+as of 2021-05-08.
+
+HTTP headers:
+
+  Server: nginx
+  Date: Sat, 08 May 2021 14:14:36 GMT
+  Content-Type: application/rss+xml; charset=utf-8
+  Content-Length: 4684
+  Connection: keep-alive
+  X-Powered-By: Perl Dancer 1.3513
+  X-Content-Type-Options: nosniff

--- a/test/data/fastmailstatus/feed.rss
+++ b/test/data/fastmailstatus/feed.rss
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<rss version="2.0"
+ xmlns:atom="http://www.w3.org/2005/Atom"
+ xmlns:blogChannel="http://backend.userland.com/blogChannelModule"
+ xmlns:content="http://purl.org/rss/1.0/modules/content/"
+ xmlns:dcterms="http://purl.org/dc/terms/"
+ xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
+>
+
+<channel>
+<title>Fastmail Status</title>
+<link>http://www.fastmailstatus.com/feed</link>
+<description></description>
+<atom:link href="http://www.fastmailstatus.com/feed" rel="self" type="application/rss+xml"/>
+
+<item>
+<title>Login &#x26; sessions - Up</title>
+<guid isPermaLink="false">2EC9D062-A182-11EB-8CC4-B51653FE9AF7</guid>
+<pubDate>Tue, 20 Apr 2021 02:43:26 +0000</pubDate>
+<dcterms:modified>2021-04-20T02:43:26Z</dcterms:modified>
+<content:encoded>We&#x27;ve resolved the issue and the ability to log out has been restored. No mail has been lost.</content:encoded>
+</item>
+<item>
+<title>Login &#x26; sessions - Warning</title>
+<guid isPermaLink="false">FE688B1E-A179-11EB-8CC4-B51653FE9AF7</guid>
+<pubDate>Tue, 20 Apr 2021 01:44:49 +0000</pubDate>
+<dcterms:modified>2021-04-20T01:44:49Z</dcterms:modified>
+<content:encoded>Customers are currently unable to log out. We&#x27;ve isolated the cause and expect it will be resolved within an hour.</content:encoded>
+</item>
+<item>
+<title>Support System - Up</title>
+<guid isPermaLink="false">E017F5EA-88F2-11EB-A9D6-823F50FE9AF7</guid>
+<pubDate>Fri, 19 Mar 2021 20:37:08 +0000</pubDate>
+<dcterms:modified>2021-03-19T20:37:08Z</dcterms:modified>
+<content:encoded>Access to the customer support system has been restored, and we&#x27;re ready to assist you!</content:encoded>
+</item>
+<item>
+<title>Support System - Down</title>
+<guid isPermaLink="false">4ADB3D56-88EE-11EB-A9D6-823F50FE9AF7</guid>
+<pubDate>Fri, 19 Mar 2021 20:04:20 +0000</pubDate>
+<dcterms:modified>2021-03-19T20:04:20Z</dcterms:modified>
+<content:encoded>Our customer support system will experience a brief downtime expected to last 10 to 30 minutes. During this time, our support team will not be responding to requests. Tickets emailed to support@fastmail.com will be delayed, but not lost.</content:encoded>
+</item>
+<item>
+<title>Support System - Up</title>
+<guid isPermaLink="false">1C464866-885B-11EB-A9D6-823F50FE9AF7</guid>
+<pubDate>Fri, 19 Mar 2021 02:30:46 +0000</pubDate>
+<dcterms:modified>2021-03-19T02:30:46Z</dcterms:modified>
+<content:encoded>Access to the customer support system has been restored, and we&#x27;re ready to assist you!</content:encoded>
+</item>
+<item>
+<title>Support System - Down</title>
+<guid isPermaLink="false">63DB21E8-8855-11EB-A9D6-823F50FE9AF7</guid>
+<pubDate>Fri, 19 Mar 2021 01:49:49 +0000</pubDate>
+<dcterms:modified>2021-03-19T01:49:49Z</dcterms:modified>
+<content:encoded>Our customer support system will experience a brief downtime expected to last 10 to 30 minutes. During this time, our support team will not be responding to requests.  Tickets emailed to support@fastmail.com will be delayed, but not lost.</content:encoded>
+</item>
+<item>
+<title>Support System - Up</title>
+<guid isPermaLink="false">A73D84DE-8095-11EB-A9D6-823F50FE9AF7</guid>
+<pubDate>Tue,  9 Mar 2021 05:09:40 +0000</pubDate>
+<dcterms:modified>2021-03-09T05:09:40Z</dcterms:modified>
+<content:encoded>The scheduled upgrade to our customer support system is complete. No tickets were lost. Thanks for your patience!</content:encoded>
+</item>
+<item>
+<title>Support System - Warning</title>
+<guid isPermaLink="false">DDE8438E-808B-11EB-A9D6-823F50FE9AF7</guid>
+<pubDate>Tue,  9 Mar 2021 03:59:37 +0000</pubDate>
+<dcterms:modified>2021-03-09T03:59:37Z</dcterms:modified>
+<content:encoded>Our customer support system is currently performing a scheduled upgrade expected to last two to three hours. During this time, our support team will not be responding to requests. Tickets emailed to support@fastmail.com will be delayed, but not lost.</content:encoded>
+</item>
+<item>
+<title>General availability - Up</title>
+<guid isPermaLink="false">A3AE9CEC-6018-11EB-9AA1-A5E048FE9AF7</guid>
+<pubDate>Tue, 26 Jan 2021 20:54:10 +0000</pubDate>
+<dcterms:modified>2021-01-26T20:54:10Z</dcterms:modified>
+<content:encoded>We&#x27;ve resolved the issue and access has been restored. No mail has been lost.</content:encoded>
+</item>
+<item>
+<title>General availability - Warning</title>
+<guid isPermaLink="false">3BBE2C00-6005-11EB-9AA1-A5E048FE9AF7</guid>
+<pubDate>Tue, 26 Jan 2021 18:35:15 +0000</pubDate>
+<dcterms:modified>2021-01-26T18:35:15Z</dcterms:modified>
+<content:encoded>A small segment of customers are experiencing interrupted access to Fastmail services. We&#x27;re looking into it.</content:encoded>
+</item>
+</channel>
+</rss>

--- a/test/data/gmane/3.expected
+++ b/test/data/gmane/3.expected
@@ -53,7 +53,8 @@ Done: https://github.com/rss2email/rss2email
 
 </pre>
 </div>
-<div class="footer"><p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/1">http://permalink.gmane.org/gmane.mail.rss2email/1</a></p>
+<div class="footer">
+<p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/1">http://permalink.gmane.org/gmane.mail.rss2email/1</a></p>
 </div>
 </div>
 </body>
@@ -105,7 +106,8 @@ mailing list (git send-email style) ?
 
 </pre>
 </div>
-<div class="footer"><p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/2">http://permalink.gmane.org/gmane.mail.rss2email/2</a></p>
+<div class="footer">
+<p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/2">http://permalink.gmane.org/gmane.mail.rss2email/2</a></p>
 </div>
 </div>
 </body>
@@ -141,7 +143,8 @@ send-email style, although I'll accept anything ;).
 
 </pre>
 </div>
-<div class="footer"><p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/3">http://permalink.gmane.org/gmane.mail.rss2email/3</a></p>
+<div class="footer">
+<p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/3">http://permalink.gmane.org/gmane.mail.rss2email/3</a></p>
 </div>
 </div>
 </body>
@@ -180,7 +183,8 @@ Also, confirming that the mailing list works.
 
 </pre>
 </div>
-<div class="footer"><p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/4">http://permalink.gmane.org/gmane.mail.rss2email/4</a></p>
+<div class="footer">
+<p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/4">http://permalink.gmane.org/gmane.mail.rss2email/4</a></p>
 </div>
 </div>
 </body>
@@ -218,7 +222,8 @@ https://github.com/rss2email/rss2email/commit/066602efa088b4a89d67e23011613b4459
 
 </pre>
 </div>
-<div class="footer"><p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/5">http://permalink.gmane.org/gmane.mail.rss2email/5</a></p>
+<div class="footer">
+<p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/5">http://permalink.gmane.org/gmane.mail.rss2email/5</a></p>
 </div>
 </div>
 </body>

--- a/test/data/gmane/4.expected
+++ b/test/data/gmane/4.expected
@@ -58,7 +58,8 @@ Done: https://github.com/rss2email/rss2email
 
 </pre>
 </div>
-<div class="footer"><p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/1">http://permalink.gmane.org/gmane.mail.rss2email/1</a></p>
+<div class="footer">
+<p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/1">http://permalink.gmane.org/gmane.mail.rss2email/1</a></p>
 </div>
 </div>
 </body>
@@ -161,7 +162,8 @@ mailing list (git send-email style) ?
 
 </pre>
 </div>
-<div class="footer"><p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/2">http://permalink.gmane.org/gmane.mail.rss2email/2</a></p>
+<div class="footer">
+<p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/2">http://permalink.gmane.org/gmane.mail.rss2email/2</a></p>
 </div>
 </div>
 </body>
@@ -238,7 +240,8 @@ send-email style, although I'll accept anything ;).
 
 </pre>
 </div>
-<div class="footer"><p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/3">http://permalink.gmane.org/gmane.mail.rss2email/3</a></p>
+<div class="footer">
+<p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/3">http://permalink.gmane.org/gmane.mail.rss2email/3</a></p>
 </div>
 </div>
 </body>
@@ -301,7 +304,8 @@ Also, confirming that the mailing list works.
 
 </pre>
 </div>
-<div class="footer"><p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/4">http://permalink.gmane.org/gmane.mail.rss2email/4</a></p>
+<div class="footer">
+<p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/4">http://permalink.gmane.org/gmane.mail.rss2email/4</a></p>
 </div>
 </div>
 </body>
@@ -367,7 +371,8 @@ https://github.com/rss2email/rss2email/commit/066602efa088b4a89d67e23011613b4459
 
 </pre>
 </div>
-<div class="footer"><p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/5">http://permalink.gmane.org/gmane.mail.rss2email/5</a></p>
+<div class="footer">
+<p>URL: <a href="http://permalink.gmane.org/gmane.mail.rss2email/5">http://permalink.gmane.org/gmane.mail.rss2email/5</a></p>
 </div>
 </div>
 </body>

--- a/test/data/quiltville/1.expected
+++ b/test/data/quiltville/1.expected
@@ -73,9 +73,10 @@ r: both; text-align: left;"><span style=3D"font-family: inherit; font-size:=
 ltville.blogspot.com/2021/02/projects-in-holding-pattern.html#more">Did You=
  Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/02/projects-in-holding-pattern.html">https://quiltville.blogspot.com/202=
-1/02/projects-in-holding-pattern.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/02/projects-in-hold=
+ing-pattern.html">https://quiltville.blogspot.com/2021/02/projects-in-holdi=
+ng-pattern.html</a></p>
 </div>
 </div>
 </body>
@@ -149,9 +150,10 @@ ehhhh!&quot; pile.</span></div><span></span><a href=3D"https://quiltville.b=
 logspot.com/2021/02/speaking-of-labels-and-more.html#more">Did You Click to=
  Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/02/speaking-of-labels-and-more.html">https://quiltville.blogspot.com/202=
-1/02/speaking-of-labels-and-more.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/02/speaking-of-labe=
+ls-and-more.html">https://quiltville.blogspot.com/2021/02/speaking-of-label=
+s-and-more.html</a></p>
 </div>
 </div>
 </body>
@@ -222,9 +224,10 @@ lear: both; text-align: left;"><span></span></div><a href=3D"https://quiltv=
 ille.blogspot.com/2021/02/into-rainy-weekend.html#more">Did You Click to Re=
 ad the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/02/into-rainy-weekend.html">https://quiltville.blogspot.com/2021/02/into=
--rainy-weekend.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/02/into-rainy-weeke=
+nd.html">https://quiltville.blogspot.com/2021/02/into-rainy-weekend.html</a=
+></p>
 </div>
 </div>
 </body>
@@ -280,9 +283,10 @@ iv><span style=3D"font-family: inherit; font-size: medium;"><span></span></=
 span></div><a href=3D"https://quiltville.blogspot.com/2021/03/rough-tumble-=
 into-march.html#more">Did You Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/rough-tumble-into-march.html">https://quiltville.blogspot.com/2021/03=
-/rough-tumble-into-march.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/rough-tumble-int=
+o-march.html">https://quiltville.blogspot.com/2021/03/rough-tumble-into-mar=
+ch.html</a></p>
 </div>
 </div>
 </body>
@@ -348,9 +352,10 @@ h. More on that later.=A0 LOL!</span></div><div class=3D"separator" style=
 pan></span></div><a href=3D"https://quiltville.blogspot.com/2021/03/more-bl=
 ue-in-studio.html#more">Did You Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/more-blue-in-studio.html">https://quiltville.blogspot.com/2021/03/mor=
-e-blue-in-studio.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/more-blue-in-stu=
+dio.html">https://quiltville.blogspot.com/2021/03/more-blue-in-studio.html<=
+/a></p>
 </div>
 </div>
 </body>
@@ -428,9 +433,10 @@ t; font-size: medium;"></span><a href=3D"https://quiltville.blogspot.com/20=
 21/03/small-studio-changes-big-studio-impact.html#more">Did You Click to Re=
 ad the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/small-studio-changes-big-studio-impact.html">https://quiltville.blogs=
-pot.com/2021/03/small-studio-changes-big-studio-impact.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/small-studio-cha=
+nges-big-studio-impact.html">https://quiltville.blogspot.com/2021/03/small-=
+studio-changes-big-studio-impact.html</a></p>
 </div>
 </div>
 </body>
@@ -501,9 +507,9 @@ r: both; text-align: left;"><span style=3D"font-family: inherit; font-size:=
 =3D"https://quiltville.blogspot.com/2021/03/monas-in-studio.html#more">Did =
 You Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/monas-in-studio.html">https://quiltville.blogspot.com/2021/03/monas-i=
-n-studio.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/monas-in-studio.=
+html">https://quiltville.blogspot.com/2021/03/monas-in-studio.html</a></p>
 </div>
 </div>
 </body>
@@ -588,9 +594,10 @@ Loaves and fishes, my friends!=A0 Loaves and finishes!<span></span></span><=
 /div><a href=3D"https://quiltville.blogspot.com/2021/03/quilting-from-sunri=
 se-to-sunset.html#more">Did You Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/quilting-from-sunrise-to-sunset.html">https://quiltville.blogspot.com=
-/2021/03/quilting-from-sunrise-to-sunset.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/quilting-from-su=
+nrise-to-sunset.html">https://quiltville.blogspot.com/2021/03/quilting-from=
+-sunrise-to-sunset.html</a></p>
 </div>
 </div>
 </body>
@@ -666,9 +673,9 @@ g a movie, taking a nap, etc.<span></span></span></div><a href=3D"https://q=
 uiltville.blogspot.com/2021/03/goodbye-hello.html#more">Did You Click to Re=
 ad the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/goodbye-hello.html">https://quiltville.blogspot.com/2021/03/goodbye-h=
-ello.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/goodbye-hello.ht=
+ml">https://quiltville.blogspot.com/2021/03/goodbye-hello.html</a></p>
 </div>
 </div>
 </body>
@@ -749,9 +756,10 @@ hort succession.<span></span></span></div><a href=3D"https://quiltville.blo=
 gspot.com/2021/03/diamond-tiles-on-day-three.html#more">Did You Click to Re=
 ad the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/diamond-tiles-on-day-three.html">https://quiltville.blogspot.com/2021=
-/03/diamond-tiles-on-day-three.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/diamond-tiles-on=
+-day-three.html">https://quiltville.blogspot.com/2021/03/diamond-tiles-on-d=
+ay-three.html</a></p>
 </div>
 </div>
 </body>
@@ -823,11 +831,11 @@ bCBmb3IgdGhlIGFiaWxpdHkgdG8gc2VlIHdoYXQgd2UgYXJlIGRvaW5nLCB3aGF0ZXZlciB3ZSBh
 cmUgZG9pbmcsIG1vcmUgY2xlYXJseS48c3Bhbj48L3NwYW4+PC9zcGFuPjwvcD48L2Rpdj48YSBo
 cmVmPSJodHRwczovL3F1aWx0dmlsbGUuYmxvZ3Nwb3QuY29tLzIwMjEvMDMvaXRzLWhlcmUtYm9u
 bmllLWstaHVudGVycy1xdWlsdGVycy10ZWNoLmh0bWwjbW9yZSI+RGlkIFlvdSBDbGljayB0byBS
-ZWFkIHRoZSBXaG9sZSBTdG9yeT88L2E+CjwvZGl2Pgo8ZGl2IGNsYXNzPSJmb290ZXIiPjxwPlVS
-TDogPGEgaHJlZj0iaHR0cHM6Ly9xdWlsdHZpbGxlLmJsb2dzcG90LmNvbS8yMDIxLzAzL2l0cy1o
-ZXJlLWJvbm5pZS1rLWh1bnRlcnMtcXVpbHRlcnMtdGVjaC5odG1sIj5odHRwczovL3F1aWx0dmls
-bGUuYmxvZ3Nwb3QuY29tLzIwMjEvMDMvaXRzLWhlcmUtYm9ubmllLWstaHVudGVycy1xdWlsdGVy
-cy10ZWNoLmh0bWw8L2E+PC9wPgo8L2Rpdj4KPC9kaXY+CjwvYm9keT4KPC9odG1sPgo=
+ZWFkIHRoZSBXaG9sZSBTdG9yeT88L2E+CjwvZGl2Pgo8ZGl2IGNsYXNzPSJmb290ZXIiPgo8cD5V
+Ukw6IDxhIGhyZWY9Imh0dHBzOi8vcXVpbHR2aWxsZS5ibG9nc3BvdC5jb20vMjAyMS8wMy9pdHMt
+aGVyZS1ib25uaWUtay1odW50ZXJzLXF1aWx0ZXJzLXRlY2guaHRtbCI+aHR0cHM6Ly9xdWlsdHZp
+bGxlLmJsb2dzcG90LmNvbS8yMDIxLzAzL2l0cy1oZXJlLWJvbm5pZS1rLWh1bnRlcnMtcXVpbHRl
+cnMtdGVjaC5odG1sPC9hPjwvcD4KPC9kaXY+CjwvZGl2Pgo8L2JvZHk+CjwvaHRtbD4K
 
 
 SENT BY: "Quiltville's Quips & Snips!!: Bonnie K. Hunter" <noreply@blogger.com>
@@ -893,9 +901,10 @@ ting may happen this weekend.<span></span></span></div><a href=3D"https://q=
 uiltville.blogspot.com/2021/03/first-road-hike-day.html#more">Did You Click=
  to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/first-road-hike-day.html">https://quiltville.blogspot.com/2021/03/fir=
-st-road-hike-day.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/first-road-hike-=
+day.html">https://quiltville.blogspot.com/2021/03/first-road-hike-day.html<=
+/a></p>
 </div>
 </div>
 </body>
@@ -968,9 +977,10 @@ re chuffed with himself than I did yesterday!<span></span></span></div><a h=
 ref=3D"https://quiltville.blogspot.com/2021/03/red-birthday-tractors-for-wi=
 n.html#more">Did You Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/red-birthday-tractors-for-win.html">https://quiltville.blogspot.com/2=
-021/03/red-birthday-tractors-for-win.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/red-birthday-tra=
+ctors-for-win.html">https://quiltville.blogspot.com/2021/03/red-birthday-tr=
+actors-for-win.html</a></p>
 </div>
 </div>
 </body>
@@ -1036,9 +1046,10 @@ wants to fix a roof every 2 years?<span></span></span></div><a href=3D"http=
 s://quiltville.blogspot.com/2021/03/up-on-roof-singing.html#more">Did You C=
 lick to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/up-on-roof-singing.html">https://quiltville.blogspot.com/2021/03/up-o=
-n-roof-singing.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/up-on-roof-singi=
+ng.html">https://quiltville.blogspot.com/2021/03/up-on-roof-singing.html</a=
+></p>
 </div>
 </div>
 </body>
@@ -1106,9 +1117,9 @@ tyle=3D"font-family: inherit; font-size: medium;">(I have that quilt - this=
 <a href=3D"https://quiltville.blogspot.com/2021/03/quilt-me-river.html#more=
 ">Did You Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/quilt-me-river.html">https://quiltville.blogspot.com/2021/03/quilt-me=
--river.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/quilt-me-river.h=
+tml">https://quiltville.blogspot.com/2021/03/quilt-me-river.html</a></p>
 </div>
 </div>
 </body>
@@ -1175,9 +1186,10 @@ ave been excitedly waiting for -<span></span></span></div><a href=3D"https:=
 //quiltville.blogspot.com/2021/03/tulip-time-pattern-time-and-gift-away.htm=
 l#more">Did You Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/tulip-time-pattern-time-and-gift-away.html">https://quiltville.blogsp=
-ot.com/2021/03/tulip-time-pattern-time-and-gift-away.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/tulip-time-patte=
+rn-time-and-gift-away.html">https://quiltville.blogspot.com/2021/03/tulip-t=
+ime-pattern-time-and-gift-away.html</a></p>
 </div>
 </div>
 </body>
@@ -1246,9 +1258,10 @@ in threes?!)<span></span></span></div><a href=3D"https://quiltville.blogspo=
 t.com/2021/03/the-rush-to-beat-rain.html#more">Did You Click to Read the Wh=
 ole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/the-rush-to-beat-rain.html">https://quiltville.blogspot.com/2021/03/t=
-he-rush-to-beat-rain.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/the-rush-to-beat=
+-rain.html">https://quiltville.blogspot.com/2021/03/the-rush-to-beat-rain.h=
+tml</a></p>
 </div>
 </div>
 </body>
@@ -1316,9 +1329,10 @@ s.<span></span></span></div><a href=3D"https://quiltville.blogspot.com/2021=
 /03/hike-little-sew-little-more.html#more">Did You Click to Read the Whole =
 Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/hike-little-sew-little-more.html">https://quiltville.blogspot.com/202=
-1/03/hike-little-sew-little-more.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/hike-little-sew-=
+little-more.html">https://quiltville.blogspot.com/2021/03/hike-little-sew-l=
+ittle-more.html</a></p>
 </div>
 </div>
 </body>
@@ -1385,9 +1399,10 @@ s and rills. My own Brigadoon.=A0=A0<span></span></span></div><a href=3D"ht=
 tps://quiltville.blogspot.com/2021/03/misty-mornings-and-coming-of-green.ht=
 ml#more">Did You Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/misty-mornings-and-coming-of-green.html">https://quiltville.blogspot.=
-com/2021/03/misty-mornings-and-coming-of-green.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/misty-mornings-a=
+nd-coming-of-green.html">https://quiltville.blogspot.com/2021/03/misty-morn=
+ings-and-coming-of-green.html</a></p>
 </div>
 </div>
 </body>
@@ -1468,9 +1483,10 @@ h the 'PULL HARD!&quot; sign, and in I went.<span></span></span></div><a hr=
 ef=3D"https://quiltville.blogspot.com/2021/03/antique-mall-on-loose.html#mo=
 re">Did You Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/antique-mall-on-loose.html">https://quiltville.blogspot.com/2021/03/a=
-ntique-mall-on-loose.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/antique-mall-on-=
+loose.html">https://quiltville.blogspot.com/2021/03/antique-mall-on-loose.h=
+tml</a></p>
 </div>
 </div>
 </body>
@@ -1503,7 +1519,8 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/with-bit-of-courage-faith-joy
 <div id="body">
 <div class="separator" style="clear: both; text-align: center;"><a href="https://1.bp.blogspot.com/-9YbQx4M4FQo/YFXdVINFg-I/AAAAAAAJMSc/FRFX6V2YjuYqxNNr7nI0ceUFGXm3ceAkwCLcBGAsYHQ/s2578/20210319_154341.jpg" style="margin-left: 1em; margin-right: 1em;"><span style="font-size: medium;"><img border="0" height="302" src="https://1.bp.blogspot.com/-9YbQx4M4FQo/YFXdVINFg-I/AAAAAAAJMSc/FRFX6V2YjuYqxNNr7nI0ceUFGXm3ceAkwCLcBGAsYHQ/w640-h302/20210319_154341.jpg" width="640" /></span></a></div><div class="separator" style="clear: both; text-align: center;"><span style="font-size: medium;"><br /></span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-size: medium;">Yesterday afternoon had me quietly and happily stitching myself into the weekend ahead.</span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-size: medium;"><br /></span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-size: medium;">I have been wanting to sit down with this project for the past AT LEAST 2 weeks.</span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-size: medium;"><br /></span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-size: medium;">It has been there, confined to its project box - nearly taunting me - as I went through my days doing all of the needful things.</span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-size: medium;"><br /></span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-size: medium;">Occasionally I'd lift the lid, pet the pieces, and say &quot;Soon, my pretties - soon!&quot;</span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-size: medium;"><br /></span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-size: medium;">That soon came yesterday afternoon on the tail end of something else ultra meaningful to my life.<span></span></span></div><a href="https://quiltville.blogspot.com/2021/03/with-bit-of-courage-faith-joy.html#more">Did You Click to Read the Whole Story?</a>
 </div>
-<div class="footer"><p>URL: <a href="https://quiltville.blogspot.com/2021/03/with-bit-of-courage-faith-joy.html">https://quiltville.blogspot.com/2021/03/with-bit-of-courage-faith-joy.html</a></p>
+<div class="footer">
+<p>URL: <a href="https://quiltville.blogspot.com/2021/03/with-bit-of-courage-faith-joy.html">https://quiltville.blogspot.com/2021/03/with-bit-of-courage-faith-joy.html</a></p>
 </div>
 </div>
 </body>
@@ -1588,10 +1605,10 @@ QmxvY2sgQmFzZSBQbHVzIGZvciBvbmUgbHVja3kgcGVyc29uIHdobyBlbnRlcnMgb24gdG9kYXkn
 cyBibG9nIHBvc3QhIEl0IGNvdWxkIGJlIHlvdSE8c3Bhbj48L3NwYW4+PC9zcGFuPjwvZGl2Pjwv
 ZGl2PjxhIGhyZWY9Imh0dHBzOi8vcXVpbHR2aWxsZS5ibG9nc3BvdC5jb20vMjAyMS8wMy9ibG9j
 a2Jhc2UtZ2lmdC1hd2F5Lmh0bWwjbW9yZSI+RGlkIFlvdSBDbGljayB0byBSZWFkIHRoZSBXaG9s
-ZSBTdG9yeT88L2E+CjwvZGl2Pgo8ZGl2IGNsYXNzPSJmb290ZXIiPjxwPlVSTDogPGEgaHJlZj0i
-aHR0cHM6Ly9xdWlsdHZpbGxlLmJsb2dzcG90LmNvbS8yMDIxLzAzL2Jsb2NrYmFzZS1naWZ0LWF3
-YXkuaHRtbCI+aHR0cHM6Ly9xdWlsdHZpbGxlLmJsb2dzcG90LmNvbS8yMDIxLzAzL2Jsb2NrYmFz
-ZS1naWZ0LWF3YXkuaHRtbDwvYT48L3A+CjwvZGl2Pgo8L2Rpdj4KPC9ib2R5Pgo8L2h0bWw+Cg==
+ZSBTdG9yeT88L2E+CjwvZGl2Pgo8ZGl2IGNsYXNzPSJmb290ZXIiPgo8cD5VUkw6IDxhIGhyZWY9
+Imh0dHBzOi8vcXVpbHR2aWxsZS5ibG9nc3BvdC5jb20vMjAyMS8wMy9ibG9ja2Jhc2UtZ2lmdC1h
+d2F5Lmh0bWwiPmh0dHBzOi8vcXVpbHR2aWxsZS5ibG9nc3BvdC5jb20vMjAyMS8wMy9ibG9ja2Jh
+c2UtZ2lmdC1hd2F5Lmh0bWw8L2E+PC9wPgo8L2Rpdj4KPC9kaXY+CjwvYm9keT4KPC9odG1sPgo=
 
 
 SENT BY: "Quiltville's Quips & Snips!!: Bonnie K. Hunter" <noreply@blogger.com>
@@ -1653,9 +1670,10 @@ mall as it looks - Jason is standing on a rock!<span></span></span></div><a=
  href=3D"https://quiltville.blogspot.com/2021/03/weekend-trail-warriors.htm=
 l#more">Did You Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/weekend-trail-warriors.html">https://quiltville.blogspot.com/2021/03/=
-weekend-trail-warriors.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/weekend-trail-wa=
+rriors.html">https://quiltville.blogspot.com/2021/03/weekend-trail-warriors=
+.html</a></p>
 </div>
 </div>
 </body>
@@ -1725,9 +1743,10 @@ br /></span></div><div class=3D"separator" style=3D"clear: both; text-align=
 ><a href=3D"https://quiltville.blogspot.com/2021/03/rivanna-runner-bound-do=
 ne.html#more">Did You Click to Read the Whole Story?</a>
 </div>
-<div class=3D"footer"><p>URL: <a href=3D"https://quiltville.blogspot.com/20=
-21/03/rivanna-runner-bound-done.html">https://quiltville.blogspot.com/2021/=
-03/rivanna-runner-bound-done.html</a></p>
+<div class=3D"footer">
+<p>URL: <a href=3D"https://quiltville.blogspot.com/2021/03/rivanna-runner-b=
+ound-done.html">https://quiltville.blogspot.com/2021/03/rivanna-runner-boun=
+d-done.html</a></p>
 </div>
 </div>
 </body>
@@ -1760,7 +1779,8 @@ X-RSS-URL: https://quiltville.blogspot.com/2021/03/bloom-baby-bloom.html
 <div id="body">
 <div class="separator" style="clear: both; text-align: center;"><span style="font-family: inherit; font-size: medium;"><br /></span></div><span style="font-family: inherit; font-size: medium;"><br /></span><div class="separator" style="clear: both; text-align: center;"><a href="https://1.bp.blogspot.com/-CSppluARwWg/YFx0jJVeimI/AAAAAAAJNoI/Cxa6aK00MD4n1o6RFdcLLnSfc28MfsW4QCLcBGAsYHQ/s2578/20210324_132242.jpg" style="margin-left: 1em; margin-right: 1em;"><span style="color: black; font-family: inherit; font-size: medium;"><img border="0" height="302" src="https://1.bp.blogspot.com/-CSppluARwWg/YFx0jJVeimI/AAAAAAAJNoI/Cxa6aK00MD4n1o6RFdcLLnSfc28MfsW4QCLcBGAsYHQ/w640-h302/20210324_132242.jpg" width="640" /></span></a></div><div class="separator" style="clear: both; text-align: center;"><span style="font-family: inherit; font-size: medium;"><br /></span></div><div class="separator" style="clear: both; text-align: center;"><span style="font-family: inherit; font-size: medium;">The forsythia are exploding!</span></div><div class="separator" style="clear: both; text-align: center;"><span style="font-family: inherit; font-size: medium;"><br /></span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-family: inherit; font-size: medium;">Yesterday's trip down to the North Carolina piedmont was a wonderful sight!</span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-family: inherit; font-size: medium;"><br /></span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-family: inherit; font-size: medium;">You know how folks oooh and ahhh at fireworks on 4th of July?</span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-family: inherit; font-size: medium;"><br /></span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-family: inherit; font-size: medium;">I'm the same way when spring arrives and trees and bushes are blooming.</span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-family: inherit; font-size: medium;"><br /></span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-family: inherit; font-size: medium;">It was like descending into OZ.</span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-family: inherit; font-size: medium;"><br /></span></div><div class="separator" style="clear: both; text-align: left;"><span style="font-family: inherit; font-size: medium;">The fog was thick all of the way between the cabin and just below the Blue Ridge Parkway - but as I got closer to Wilkesboro, the fog dissipated and and left me with a clear view of blooming loveliness that has not reached our higher elevations yet.<span></span></span></div><a href="https://quiltville.blogspot.com/2021/03/bloom-baby-bloom.html#more">Did You Click to Read the Whole Story?</a>
 </div>
-<div class="footer"><p>URL: <a href="https://quiltville.blogspot.com/2021/03/bloom-baby-bloom.html">https://quiltville.blogspot.com/2021/03/bloom-baby-bloom.html</a></p>
+<div class="footer">
+<p>URL: <a href="https://quiltville.blogspot.com/2021/03/bloom-baby-bloom.html">https://quiltville.blogspot.com/2021/03/bloom-baby-bloom.html</a></p>
 </div>
 </div>
 </body>

--- a/test/data/tails/2.expected
+++ b/test/data/tails/2.expected
@@ -191,7 +191,8 @@ Tails 4.8 directly:</p>
 Tails</a> (<a href="https://tails.boum.org/donate/?r=4.8">donating</a> is only one of
 them). Come <a href="https://tails.boum.org/about/contact/index.en.html#tails-dev">talk to us</a>!</p>
 </div>
-<div class="footer"><p>URL: <a href="https://tails.boum.org/news/version_4.8/index.en.html">https://tails.boum.org/news/version_4.8/index.en.html</a></p>
+<div class="footer">
+<p>URL: <a href="https://tails.boum.org/news/version_4.8/index.en.html">https://tails.boum.org/news/version_4.8/index.en.html</a></p>
 </div>
 </div>
 </body>
@@ -430,7 +431,8 @@ Tails 4.9 directly:</p>
 Tails</a> (<a href="https://tails.boum.org/donate/?r=4.9">donating</a> is only one of
 them). Come <a href="https://tails.boum.org/about/contact/index.en.html#tails-dev">talk to us</a>!</p>
 </div>
-<div class="footer"><p>URL: <a href="https://tails.boum.org/news/version_4.9/index.en.html">https://tails.boum.org/news/version_4.9/index.en.html</a></p>
+<div class="footer">
+<p>URL: <a href="https://tails.boum.org/news/version_4.9/index.en.html">https://tails.boum.org/news/version_4.9/index.en.html</a></p>
 </div>
 </div>
 </body>
@@ -634,7 +636,8 @@ Tails 4.10 directly:</p>
 Tails</a> (<a href="https://tails.boum.org/donate/?r=4.10">donating</a> is only one of
 them). Come <a href="https://tails.boum.org/about/contact/index.en.html#tails-dev">talk to us</a>!</p>
 </div>
-<div class="footer"><p>URL: <a href="https://tails.boum.org/news/version_4.10/index.en.html">https://tails.boum.org/news/version_4.10/index.en.html</a></p>
+<div class="footer">
+<p>URL: <a href="https://tails.boum.org/news/version_4.10/index.en.html">https://tails.boum.org/news/version_4.10/index.en.html</a></p>
 </div>
 </div>
 </body>
@@ -877,7 +880,8 @@ automatic upgrade, please try to do a <a href="https://tails.boum.org/doc/upgrad
 Tails</a> (<a href="https://tails.boum.org/donate/?r=4.11-rc1">donating</a> is only one of
 them). Come <a href="https://tails.boum.org/about/contact/index.en.html#tails-dev">talk to us</a>!</p>
 </div>
-<div class="footer"><p>URL: <a href="https://tails.boum.org/news/test_4.11-rc1/">https://tails.boum.org/news/test_4.11-rc1/</a></p>
+<div class="footer">
+<p>URL: <a href="https://tails.boum.org/news/test_4.11-rc1/">https://tails.boum.org/news/test_4.11-rc1/</a></p>
 </div>
 </div>
 </body>
@@ -1098,7 +1102,8 @@ Tails 4.11 directly:</p>
 Tails</a> (<a href="https://tails.boum.org/donate/?r=4.11">donating</a> is only one of
 them). Come <a href="https://tails.boum.org/about/contact/index.en.html#tails-dev">talk to us</a>!</p>
 </div>
-<div class="footer"><p>URL: <a href="https://tails.boum.org/news/version_4.11/index.en.html">https://tails.boum.org/news/version_4.11/index.en.html</a></p>
+<div class="footer">
+<p>URL: <a href="https://tails.boum.org/news/version_4.11/index.en.html">https://tails.boum.org/news/version_4.11/index.en.html</a></p>
 </div>
 </div>
 </body>
@@ -1319,7 +1324,8 @@ Tails 4.12 directly:</p>
 Tails</a> (<a href="https://tails.boum.org/donate/?r=4.12">donating</a> is only one of
 them). Come <a href="https://tails.boum.org/about/contact/index.en.html#tails-dev">talk to us</a>!</p>
 </div>
-<div class="footer"><p>URL: <a href="https://tails.boum.org/news/version_4.12/index.en.html">https://tails.boum.org/news/version_4.12/index.en.html</a></p>
+<div class="footer">
+<p>URL: <a href="https://tails.boum.org/news/version_4.12/index.en.html">https://tails.boum.org/news/version_4.12/index.en.html</a></p>
 </div>
 </div>
 </body>
@@ -1542,7 +1548,8 @@ Tails 4.13 directly:</p>
 Tails</a> (<a href="https://tails.boum.org/donate/?r=4.13">donating</a> is only one of
 them). Come <a href="https://tails.boum.org/about/contact/index.en.html#tails-dev">talk to us</a>!</p>
 </div>
-<div class="footer"><p>URL: <a href="https://tails.boum.org/news/version_4.13/index.en.html">https://tails.boum.org/news/version_4.13/index.en.html</a></p>
+<div class="footer">
+<p>URL: <a href="https://tails.boum.org/news/version_4.13/index.en.html">https://tails.boum.org/news/version_4.13/index.en.html</a></p>
 </div>
 </div>
 </body>
@@ -1703,7 +1710,8 @@ make the verification faster. If you know WebAssembly, see if you can help us
 <p>See also our <a href="https://tails.boum.org/contribute/design/download_verification/">design document on the security and threat model of the
 download verification</a>.</p>
 </div>
-<div class="footer"><p>URL: <a href="https://tails.boum.org/news/verification_extension_deprecation/index.en.html">https://tails.boum.org/news/verification_extension_deprecation/index.en.html</a></p>
+<div class="footer">
+<p>URL: <a href="https://tails.boum.org/news/verification_extension_deprecation/index.en.html">https://tails.boum.org/news/verification_extension_deprecation/index.en.html</a></p>
 </div>
 </div>
 </body>
@@ -1897,7 +1905,8 @@ Tails 4.14 directly:</p>
 Tails</a> (<a href="https://tails.boum.org/donate/?r=4.14">donating</a> is only one of
 them). Come <a href="https://tails.boum.org/about/contact/index.en.html#tails-dev">talk to us</a>!</p>
 </div>
-<div class="footer"><p>URL: <a href="https://tails.boum.org/news/version_4.14/index.en.html">https://tails.boum.org/news/version_4.14/index.en.html</a></p>
+<div class="footer">
+<p>URL: <a href="https://tails.boum.org/news/version_4.14/index.en.html">https://tails.boum.org/news/version_4.14/index.en.html</a></p>
 </div>
 </div>
 </body>
@@ -2150,7 +2159,8 @@ surveillance and censorship!</p>
 
 <div class="cfa"><a href="https://tails.boum.org/donate/?r=ab">Donate</a></div>
 </div>
-<div class="footer"><p>URL: <a href="https://tails.boum.org/news/achievements_in_2020/index.en.html">https://tails.boum.org/news/achievements_in_2020/index.en.html</a></p>
+<div class="footer">
+<p>URL: <a href="https://tails.boum.org/news/achievements_in_2020/index.en.html">https://tails.boum.org/news/achievements_in_2020/index.en.html</a></p>
 </div>
 </div>
 </body>


### PR DESCRIPTION
Before the regression, a URL of "None" was inserted in the href attribute, but with 4cdf574 (Perform HTML escaping on text to be appended to HTML, 2021-03-19) applied, calling saxutils.escape on None had crashed r2e with:

    Traceback (most recent call last):
      File "/rss2email/test/test.py", line 62, in fn
        self.run_single_test(config_path=test_path)
      File "/rss2email/test/test.py", line 135, in run_single_test
        feed.run()
      File "/rss2email/rss2email/feed.py", line 933, in run
        for (guid, state, sender, message) in self._process(parsed):
      File "/rss2email/rss2email/feed.py", line 394, in _process
        processed = self._process_entry(parsed=parsed, entry=entry)
      File "/rss2email/rss2email/feed.py", line 544, in _process_entry
        content = self._process_entry_content(
      File "/rss2email/rss2email/feed.py", line 821, in _process_entry_content
        _saxutils.escape(link), _saxutils.escape(subject)),
      File "/lib/python3.9/xml/sax/saxutils.py", line 27, in escape
        data = data.replace("&", "&amp;")
    AttributeError: 'NoneType' object has no attribute 'replace'
