### PR TITLE
Add subject format option

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 UNRELEASED
     * Fix crash on html-mail entries with no URL
+    * Add a new `subject-format` setting, customise the subject line
 
 v3.13 (2021-04-03)
     * Switch to feedparser 6

--- a/r2e.1
+++ b/r2e.1
@@ -176,7 +176,7 @@ False: Just use the 'from' email instead.
 If empty, only use the feed email address rather than
 friendly name plus email address.  Available attributes may
 include 'feed', 'feed-name', 'feed-url', 'feed-title', 'author', and
-'publisher', but only 'feed', 'feed-name', and 'feed-url' are guaranteed.
+\'publisher', but only 'feed', 'feed-name', and 'feed-url' are guaranteed.
 .IP to
 Set this to default To email addresses.
 .RE
@@ -226,6 +226,9 @@ enabled, the usual 'post-process' hook gets to message the
 per-entry messages, but this hook is called with the full
 digest message before it is mailed.
 Example: digest-post-process = 'rss2email.post_process.downcase downcase_message'
+.IP subject-format
+The format for the Subject line.  Available attributes are
+\'feed', 'feed-name', 'feed-url', 'feed-title'.
 .RE
 .SS HTML conversion
 .IP html-mail

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -156,6 +156,10 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         # digest message before it is mailed.
         # Example: digest-post-process = 'rss2email.post_process.downcase downcase_message'
         ('digest-post-process', ''),
+        # The format for the Subject line.  Available attributes are
+        # 'feed', 'feed-name', 'feed-url', 'feed-title'.
+        ('subject-format', '{feed-title}'),
+
         ## HTML conversion
         # True: Send text/html messages when possible.
         # False: Convert HTML to plain text.

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -509,7 +509,7 @@ class Feed (object):
         new_state['hash'] = new_hash
 
         sender = self._get_entry_email(parsed=parsed, entry=entry)
-        subject = self._get_entry_title(entry)
+        subject = self._get_entry_subject(entry=entry)
 
         message_id = '<{0}@{1}>'.format(_uuid.uuid4(), platform.node())
         in_reply_to = old_state.get('message_id') if old_state is not None else None
@@ -668,6 +668,16 @@ class Feed (object):
         if 'name' in feed.get('publisher_detail', []):
             data['publisher'] = feed.publisher_detail.name
         name = self.name_format.format(**data)
+        return _html.unescape(name)
+
+    def _get_entry_subject(self, entry):
+        data = {
+            'feed': self,
+            'feed-name': self.name,
+            'feed-url': self.url,
+            'feed-title': self._get_entry_title(entry),
+            }
+        name = self.subject_format.format(**data)
         return _html.unescape(name)
 
     def _validate_email(self, email, default=None):

--- a/test/data/allthingsrss/7.config
+++ b/test/data/allthingsrss/7.config
@@ -1,0 +1,4 @@
+[DEFAULT]
+to = a@b.com
+date-header = True
+subject-format = 123 {feed-name} -> {feed-title}

--- a/test/data/allthingsrss/7.expected
+++ b/test/data/allthingsrss/7.expected
@@ -1,0 +1,110 @@
+SENT BY: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+To: a@b.com
+Subject: 123 test -> Version 2.67 Released
+Date: Tue, 21 Sep 2010 16:55:07 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/allthingsrss/feed.atom
+X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=62
+X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/aGbf5Gefkmc/
+X-RSS-TAGS: Uncategorized
+
+Version 2.67 of rss2email is now available for both
+[Linux](http://www.allthingsrss.com/rss2email/rss2email-2.67.tar.gz) and
+[Windows](http://www.allthingsrss.com/rss2email/rss2email-2.67.zip), which
+includes the latest development version of feedparser. Changes from the
+previous version:
+
+  * Fixed entries that include an id which is blank (i.e., an empty string) were being resent
+  * Fixed some entries not being sent by email because they had bad From headers
+  * Fixed From headers with HTML entities encoded twice
+  * Compatibility changes to support most recent development versions of feedparser
+  * Compatibility changes to support Google Reader feeds
+
+Complete list in the official
+[CHANGELOG](http://www.allthingsrss.com/rss2email/changelog).
+
+[![](http://feedads.g.doubleclick.net/~a/Sjq8v-Lq2dNKzkelsypiC4fjPLM/0/di)](http://feedads.g.doubleclick.net/~a/Sjq8v-Lq2dNKzkelsypiC4fjPLM/0/da)  
+[![](http://feedads.g.doubleclick.net/~a/Sjq8v-Lq2dNKzkelsypiC4fjPLM/1/di)](http://feedads.g.doubleclick.net/~a/Sjq8v-Lq2dNKzkelsypiC4fjPLM/1/da)
+
+![](http://feeds.feedburner.com/~r/allthingsrss/hJBr/~4/aGbf5Gefkmc)
+
+
+
+URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/aGbf5Gefkmc/
+
+SENT BY: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+To: a@b.com
+Subject: 123 test -> Version 2.68 Released with Actual New Features
+Date: Fri, 01 Oct 2010 18:21:26 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/allthingsrss/feed.atom
+X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=72
+X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/bT-I0iH2vw8/
+X-RSS-TAGS: Uncategorized
+
+Unlike the last few versions of rss2email that have trickled out, I finally
+got around to adding a few new oft-requested features! Version 2.68 of
+rss2email is now available for both
+[Linux](http://www.allthingsrss.com/rss2email/rss2email-2.68.tar.gz) and
+[Windows](http://www.allthingsrss.com/rss2email/rss2email-2.68.zip).
+
+Changes from the previous version:
+
+  * Added ability to pause/resume checking of individual feeds through pause and unpause commands
+  * Added ability to import and export OPML feed lists through importopml and exportopml commands
+
+Complete list in the official
+[CHANGELOG](http://www.allthingsrss.com/rss2email/changelog).
+
+**Pause/Unpause**
+
+Through `r2e pause _n_` where _n_ is a feed number, you can temporarily
+suspend checking that feed for new content. To start checking it again, simply
+run `r2e unpause _n_`. When you `r2e list`, an asterisk indicates that the
+feed is currently unpaused and active.
+
+[![](http://feedads.g.doubleclick.net/~a/nYgTsIUsS9pmvRZ6092XGGHnNKg/0/di)](http://feedads.g.doubleclick.net/~a/nYgTsIUsS9pmvRZ6092XGGHnNKg/0/da)  
+[![](http://feedads.g.doubleclick.net/~a/nYgTsIUsS9pmvRZ6092XGGHnNKg/1/di)](http://feedads.g.doubleclick.net/~a/nYgTsIUsS9pmvRZ6092XGGHnNKg/1/da)
+
+![](http://feeds.feedburner.com/~r/allthingsrss/hJBr/~4/bT-I0iH2vw8)
+
+
+
+URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/bT-I0iH2vw8/
+
+SENT BY: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+MIME-Version: 1.0
+Content-Type: text/plain; charset="us-ascii"
+Content-Transfer-Encoding: 7bit
+From: "rss2email: Lindsey Smith" <user@rss2email.invalid>
+To: a@b.com
+Subject: 123 test -> How to Read RSS Feeds in Emacs
+Date: Fri, 05 Nov 2010 17:36:14 -0000
+Message-ID: <...@dev.null.invalid>
+User-Agent: rss2email/...
+List-ID: <test.localhost>
+List-Post: NO (posting not allowed on this list)
+X-RSS-Feed: data/allthingsrss/feed.atom
+X-RSS-ID: http://www.allthingsrss.com/rss2email/?p=79
+X-RSS-URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/JryfOLe_q6c/
+X-RSS-TAGS: Uncategorized
+
+something something irrelevant
+
+
+
+URL: http://feedproxy.google.com/~r/allthingsrss/hJBr/~3/JryfOLe_q6c/


### PR DESCRIPTION
My mail provider prevents setting the `From` address, so I've been finding it difficult to quickly identify which feed a new email is from. This change adds a `subject-format` option that lets you configure the subject line to make that more apparent. I use `subject-format = {feed-name}: {feed-title}` which makes it much easier.

First contribution to the project, so happy to make changes if desired. Thanks.