### PR TITLE
Fix manpage formating

### DIFF
--- a/r2e.1
+++ b/r2e.1
@@ -175,8 +175,8 @@ False: Just use the 'from' email instead.
 .IP name-format
 If empty, only use the feed email address rather than
 friendly name plus email address.  Available attributes may
-include 'feed', 'feed-name', 'feed-url', 'feed-title', 'author', and
-\'publisher', but only 'feed', 'feed-name', and 'feed-url' are guaranteed.
+include 'feed', 'feed-name', 'feed-url', 'feed-title', 'author', and 'publisher',
+but only 'feed', 'feed-name', and 'feed-url' are guaranteed.
 .IP to
 Set this to default To email addresses.
 .RE
@@ -227,8 +227,8 @@ per-entry messages, but this hook is called with the full
 digest message before it is mailed.
 Example: digest-post-process = 'rss2email.post_process.downcase downcase_message'
 .IP subject-format
-The format for the Subject line.  Available attributes are
-\'feed', 'feed-name', 'feed-url', 'feed-title'.
+The format for the Subject line.  Available attributes
+are 'feed', 'feed-name', 'feed-url', 'feed-title'.
 .RE
 .SS HTML conversion
 .IP html-mail


### PR DESCRIPTION
"\'" renders as an acute accent and just a "'" at the beginning of a
line is interpreted as Groff command. So reformat the line instead.