### PR TITLE
Pass user-agent to feedparser

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -383,6 +383,7 @@ class Feed (object):
             kwargs['handlers'] = [
                 _urllib_request.ProxyHandler({ 'http': proxy, 'https': proxy })
             ]
+        kwargs['agent'] = config['user-agent']
         f = _util.TimeLimitedFunction('feed {}'.format(self.name), timeout, _feedparser.parse)
         return f(self.url, self.etag, modified=self.modified, **kwargs)
 


### PR DESCRIPTION
Hi there, would it be possible to pass the user agent configured to feedparser. Have a bunch of feeds that report 403 without this.