### PR TITLE
Add a new http-user-agent config.

### DIFF
--- a/r2e.1
+++ b/r2e.1
@@ -260,6 +260,9 @@ Path to sendmail (or compatible)
 .IP user-agent
 String to use as User-Agent in outgoing emails. If present, __VERSION__ and
 __URL__ are replaced with rss2email version number and webpage
+.IP http-user-agent
+String to use as HTTP User-Agent in web requests. If present, __VERSION__ and
+__URL__ are replaced with rss2email version number and webpage
 .RE
 .SS SMTP configuration
 .IP smtp-auth

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -88,6 +88,8 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ('from', 'user@rss2email.invalid'),
         # The User-Agent default string (rss2email __VERSION__ and __URL__ is replaced)
         ('user-agent', 'rss2email/__VERSION__ (__URL__)'),
+        # The HTTP User-Agent default string (rss2email __VERSION__ and __URL__ is replaced)
+        ('http-user-agent', 'rss2email/__VERSION__ (__URL__)'),
         # Transfer-Encoding. For local mailing it is safe and
         # convenient to use 8bit.
         ('use-8bit', str(False)),

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -187,6 +187,9 @@ class Feed (object):
     _default_configured_attributes[
         _default_configured_attributes.index('user_agent')
         ] = '_user_agent'  # `user_agent` is a getter that does substitution
+    _default_configured_attributes[
+        _default_configured_attributes.index('http_user_agent')
+        ] = '_http_user_agent'  # `http_user_agent` is a getter that does substitution
     # all attributes that are saved/loaded from .config
     _configured_attributes = (
         _non_default_configured_attributes + _default_configured_attributes)
@@ -236,6 +239,12 @@ class Feed (object):
     @property
     def user_agent(self):
         return self._user_agent.\
+            replace('__VERSION__', __version__).\
+            replace('__URL__', __url__)
+
+    @property
+    def http_user_agent(self):
+        return self._http_user_agent.\
             replace('__VERSION__', __version__).\
             replace('__URL__', __url__)
 
@@ -384,7 +393,7 @@ class Feed (object):
                 _urllib_request.ProxyHandler({ 'http': proxy, 'https': proxy })
             ]
         f = _util.TimeLimitedFunction('feed {}'.format(self.name), timeout, _feedparser.parse)
-        return f(self.url, self.etag, modified=self.modified, **kwargs)
+        return f(self.url, self.etag, modified=self.modified, agent=self.http_user_agent, **kwargs)
 
     def _process(self, parsed):
         _LOG.info('process {}'.format(self))

--- a/rss2email/post_process/redirect.py
+++ b/rss2email/post_process/redirect.py
@@ -63,7 +63,7 @@ def process(feed, parsed, entry, guid, message):
     for link in links:
         try:
             request = urllib.request.Request(link)
-            request.add_header('User-agent', feed.user_agent)
+            request.add_header('User-agent', feed.http_user_agent)
             direct_link = urllib.request.urlopen(request).geturl()
         except Exception as e:
             LOG.warning('could not follow redirect for {}: {}'.format(

--- a/test/test.py
+++ b/test/test.py
@@ -192,6 +192,20 @@ def webserver_for_test_fetch(queue, num_requests, wait_time):
     finally:
         httpd.server_close()
 
+def webserver_for_test_user_agent(queue):
+    class AgentDumper(NoLogHandler):
+        def do_GET(self):
+            queue.put(self.headers["User-Agent"])
+            super().do_GET()
+
+    httpd = http.server.HTTPServer(('', 0), AgentDumper)
+    try:
+        port = httpd.server_address[1]
+        queue.put(port)
+        httpd.handle_request()
+    finally:
+        httpd.server_close()
+
 def webserver_for_test_if_fetch(queue, timeout):
     """Spawn a webserver for `timeout` seconds"""
     httpd = http.server.HTTPServer(('', 0), NoLogHandler)
@@ -231,6 +245,36 @@ class TestFetch(unittest.TestCase):
 
         if result == "too fast":
             raise Exception("r2e did not delay long enough!")
+
+    def test_http_user_agent(self):
+        http_user_agent = 'my-test-agent'
+        http_user_agent_cfg = """[DEFAULT]
+        to = example@example.com
+        http-user-agent = {}
+        """.format(http_user_agent)
+        http_default_agent_cfg = """[DEFAULT]
+        to = example@example.com
+        """
+
+        queue = multiprocessing.Queue()
+        webserver_proc = multiprocessing.Process(target=webserver_for_test_user_agent, args=(queue,))
+        webserver_proc.start()
+        port = queue.get()
+
+        with ExecContext(http_user_agent_cfg) as ctx:
+            ctx.call("add", 'test', 'http://127.0.0.1:{port}/dummy'.format(port = port))
+            ctx.call("run", "--no-send")
+        self.assertEqual(queue.get(), http_user_agent)
+
+        queue = multiprocessing.Queue()
+        webserver_proc = multiprocessing.Process(target=webserver_for_test_user_agent, args=(queue,))
+        webserver_proc.start()
+        port = queue.get()
+
+        with ExecContext(http_default_agent_cfg) as ctx:
+            ctx.call("add", 'test', 'http://127.0.0.1:{port}/dummy'.format(port = port))
+            ctx.call("run", "--no-send")
+        self.assertNotEqual(queue.get(), http_user_agent)
 
     def test_fetch_parallel(self):
         if not UNIX:


### PR DESCRIPTION
Gives the ability to override the HTTP user agent.

This should take care of https://github.com/rss2email/rss2email/issues/154

Also related to https://github.com/rss2email/rss2email/issues/120 (which applies to the mail user agent).