### PR TITLE
Add http-header config option to pass custom HTTP headers.

### DIFF
--- a/r2e.1
+++ b/r2e.1
@@ -185,6 +185,8 @@ Set this to default To email addresses.
 Set an HTTP proxy (e.g. 'http://your.proxy.here:8080/')
 .IP feed-timeout
 Set the timeout (in seconds) for feed server response
+.IP http-header
+Set custom HTTP headers to be sent with the feed requests
 .RE
 .SS Processing
 .IP active

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -112,6 +112,8 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ('feed-timeout', str(60)),
         # Set the time (in seconds) to sleep between fetches from the same server
         ('same-server-fetch-interval', str(0)),
+        # Custom HTTP headers (newline separated)
+        ('http-header', ''),
 
         ### Processing
         # True: Fetch, process, and email feeds.

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -383,6 +383,16 @@ class Feed (object):
             kwargs['handlers'] = [
                 _urllib_request.ProxyHandler({ 'http': proxy, 'https': proxy })
             ]
+        extra_headers = {}
+        custom_headers = config['http-header']
+        if custom_headers:
+            for header in self.http_header.splitlines():
+                if ':' in header:
+                    key,value = header.split(':', 1)
+                    extra_headers[key.strip()] = value.strip()
+                else:
+                    _LOG.warning('malformed http-header: {}'.format(self.bonus_header))
+        kwargs['request_headers'] = extra_headers
         f = _util.TimeLimitedFunction('feed {}'.format(self.name), timeout, _feedparser.parse)
         return f(self.url, self.etag, modified=self.modified, **kwargs)
 


### PR DESCRIPTION
This can be used to pass cookies for examples for feeds that may require
them.