### PR TITLE
Fix a couple of HTTP user agent regressions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,9 @@ UNRELEASED
     * Fix exception when parsing a feed with a linebreak in its title
     * Add a new `subject-format` setting, customise the subject line
     * Removed '$' interpolation in config file to allow URLs containing dollar signs. Interpolation was not fully supported, and the placeholder would not survive a second save. Config files with ${...} placeholders will need to be manually edited after upgrading, or a save forced by adding and removing a fake feed before upgrading.
+    * Fix default HTTP User-Agent to use `rss2email` instead of `feedparser`, and fix `user-agent` setting to consistently apply to both outgoing emails and HTTP requests. This introduces a couple of potentially breaking changes:
+       o Configurations that came to rely on the `feedparser` UA string should adjust to the updated UA string going forward.
+       o Configurations that came to rely on the unintended behaviour, that configuring the User-Agent header in emails does not affect HTTP requests, should use a custom `post-process` hook instead.
 
 v3.13 (2021-04-03)
     * Switch to feedparser 6

--- a/r2e.1
+++ b/r2e.1
@@ -257,9 +257,6 @@ Wrap long lines at position. Any negative value for no wrapping, 0 for 78 width
 Select protocol from: sendmail, smtp, imap, maildir
 .IP sendmail
 Path to sendmail (or compatible)
-.IP user-agent
-String to use as User-Agent in outgoing emails. If present, __VERSION__ and
-__URL__ are replaced with rss2email version number and webpage
 .RE
 .SS SMTP configuration
 .IP smtp-auth
@@ -296,6 +293,10 @@ Path of maildir to write messages into
 Mailbox within maildir-path to write messages into
 .RE
 .SS Miscellaneous
+.IP user-agent
+String to use as HTTP User-Agent in web requests and as the User-Agent header in
+outgoing emails. If present, __VERSION__ and __URL__ are replaced with rss2email
+version number and webpage.
 .IP verbose
 Verbosity (one of 'error', 'warning', 'info', or 'debug').
 .RE

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -384,7 +384,7 @@ class Feed (object):
                 _urllib_request.ProxyHandler({ 'http': proxy, 'https': proxy })
             ]
         f = _util.TimeLimitedFunction('feed {}'.format(self.name), timeout, _feedparser.parse)
-        return f(self.url, self.etag, modified=self.modified, **kwargs)
+        return f(self.url, self.etag, modified=self.modified, agent=self.user_agent, **kwargs)
 
     def _process(self, parsed):
         _LOG.info('process {}'.format(self))


### PR DESCRIPTION
Based on work in and closes #209. Closes #120 and fixes #154 (ability to configure HTTP user agent). It also fixes a regression from version 3.11, where `feedparser` was used in the User-Agent for fetching feeds instead of the previously-used `rss2email`.

Read [this comment in the #209 thread](https://github.com/rss2email/rss2email/pull/209#issuecomment-1102715056) for the full context. The gist is in the commit message:

> It is worth noting that https://github.com/rss2email/rss2email/commit/f57513aa9868ce5d18148eb4eb787599c2b5d2fc (Use configured user-agent string and replace \_VERSION\_ with \_\_version\_\_ value, 2019-09-13) changed the semantics of the `user-agent` configuration unintentionally. This error was unfortunately added to the documentation in https://github.com/rss2email/rss2email/commit/574ba59ae7032e5d6e6a0ae77b22a06487f6c247 (Add user-agent documentation to man page, 2019-09-13), causing further confusion.

This PR is an attempt to clear up that confusion.