### PR TITLE
Add config parameter: email-auth-from-env

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ UNRELEASED
     * Fix exception when parsing a feed with a linebreak in its title
     * Add a new `subject-format` setting, customise the subject line
     * Removed '$' interpolation in config file to allow URLs containing dollar signs. Interpolation was not fully supported, and the placeholder would not survive a second save. Config files with ${...} placeholders will need to be manually edited after upgrading, or a save forced by adding and removing a fake feed before upgrading.
+    * Add a new `email-auth-from-env` setting, interpret username/password as env variable names
 
 v3.13 (2021-04-03)
     * Switch to feedparser 6

--- a/README.rst
+++ b/README.rst
@@ -175,12 +175,12 @@ You can make the email address whatever you want, but your mail server
 requires that the ``yoursite.com`` part actually exists.
 
 
-SMTP
-----
+SMTP/IMAP
+---------
 
 By default, rss2email uses sendmail (or an equivalent) to send
 outgoing email.  If you don't have such a program installed, or simply
-prefer to use SMTP__ directly, edit the configuration file and fill in
+prefer to use SMTP__ or IMAP__, edit the configuration file and fill in
 your outgoing email server's details::
 
   [DEFAULT]
@@ -197,6 +197,14 @@ If your server requires you to login, change ``smtp-auth = False`` to
   smtp-username = username
   smtp-password = password
 
+To avoid storing your credentials in the configuration file, you may
+optionally set ``email-auth-from-env = True`` and instead reference the names
+of environment variables containing them::
+
+  email-auth-from-env = True
+  smtp-username = RSS2EMAIL_USERNAME
+  smtp-password = RSS2EMAIL_PASSWORD
+
 If your server requires an `TLS/SSL`_ connection (SMTPS), change
 ``smtp-ssl = False`` to ``smtp-ssl = True``.  If your server does
 not require a SMTPS connection but you request authentication,
@@ -204,6 +212,7 @@ rss2email will use STARTTLS_ to encrypt the connection before sending
 your login credentials to the server.
 
 __ `Simple Mail Transport Protocol`_
+__ `Internet Message Access Protocol`_
 
 Post-processing
 ---------------
@@ -290,3 +299,4 @@ checking it in.
 .. _windows scheduler: http://www.iopus.com/guides/winscheduler.htm
 .. _cron: http://en.wikipedia.org/wiki/Cron
 .. _Libera IRC server: https://libera.chat/
+.. _Internet Message Access Protocol: https://en.wikipedia.org/wiki/Internet_Message_Access_Protocol

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -222,7 +222,8 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ### Mailing
         # Select protocol from: sendmail, smtp, imap
         ('email-protocol', 'sendmail'),
-        # True: Use SMTP_SERVER to send mail.
+        # Interpret username/password as names of environment variables containing their values
+        ('email-auth-from-env', str(False)),
         # Sendmail (or compatible) configuration
         ('sendmail', '/usr/sbin/sendmail'),  # Path to sendmail (or compatible)
         ('sendmail_config', ''),

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -213,6 +213,9 @@ def smtp_send(recipient, message, config=None, section='DEFAULT'):
     if smtp_auth:
         username = config.get(section, 'smtp-username')
         password = config.get(section, 'smtp-password')
+        if config.getboolean(section, 'email-auth-from-env'):
+            username = _os.getenv(username, '')
+            password = _os.getenv(password, '')
         try:
             if not ssl:
                 smtp.starttls(context=context)
@@ -239,7 +242,10 @@ def imap_send(message, config=None, section='DEFAULT'):
     try:
         if config.getboolean(section, 'imap-auth'):
             username = config.get(section, 'imap-username')
-            password = config.get(section, 'imap-password')
+            password = config.get(section, 'imap-password') 
+            if config.getboolean(section, 'email-auth-from-env'):
+                username = _os.getenv(username, '')
+                password = _os.getenv(password, '')            
             try:
                 if not ssl:
                     imap.starttls()

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -242,7 +242,7 @@ def imap_send(message, config=None, section='DEFAULT'):
     try:
         if config.getboolean(section, 'imap-auth'):
             username = config.get(section, 'imap-username')
-            password = config.get(section, 'imap-password') 
+            password = config.get(section, 'imap-password')
             if config.getboolean(section, 'email-auth-from-env'):
                 username = _os.getenv(username, '')
                 password = _os.getenv(password, '')            


### PR DESCRIPTION
I propose a configuration parameter `email-auth-from-env`. If `True`, it causes rss2email to interpret the SMTP/IMAP username and password as the _names of environment variables_ from which to extract the _actual_ credentials.

See #5 and (more recently) #219 for background.

In #219, a couple of broader solutions were offered that would affect the processing of the entire configuration file. These deserve consideration, especially for users with many feeds requiring authentication. However, since the most common use case is likely to be the abstraction of email credentials, I offer this simple solution. It:

- does not require a separate config file
- does not affect existing configurations
- is "discoverable" since it will be added to `rss2email.cfg` automatically on writes.
- can coexist with the broader/long-term solutions proposed so far.

Input is welcome!