### PR TITLE
HTTP statuses cleanup

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -411,6 +411,10 @@ class Feed (object):
             _LOG.info('redirect {} from {} to {}'.format(
                     self.name, self.url, parsed['url']))
             self.url = parsed['url']
+        elif status == 410:
+            _LOG.info('deactivate {} because {} is gone'.format(
+                    self.name, self.url))
+            self.active = False
         elif status >= 400:
             raise _error.HTTPError(status=status, feed=self)
 

--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -407,11 +407,11 @@ class Feed (object):
         warned = False
         status = getattr(parsed, 'status', 200)
         _LOG.debug('HTTP status {}'.format(status))
-        if status == 301:
+        if status in [301, 308]:
             _LOG.info('redirect {} from {} to {}'.format(
                     self.name, self.url, parsed['url']))
             self.url = parsed['url']
-        elif status not in [200, 302, 304, 307]:
+        elif status >= 400:
             raise _error.HTTPError(status=status, feed=self)
 
         http_headers = parsed.get('headers', {})


### PR DESCRIPTION
Fixes #229 by not attempting to enumerate all non-error statuses explicitly.

While researching for this fix, I noticed that HTTP status 308 (Moved Permanently) is another form of permanent redirect and corrected the code to include that case. Note that currently feedparser does not handle HTTP status 308 as a redirect, but this will change when (hopefully) https://github.com/kurtmckee/feedparser/pull/326 gets merged and released there.

In addition, while I was in the area, I added handling of status 410 (Gone) in similar vein to the handling of permanent redirects, by marking the feed as inactive (as suggested [in the feedparser documentation](https://feedparser.readthedocs.io/en/latest/http-redirect.html#noticing-feeds-marked-gone)).