### PR TITLE
Add docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,96 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: '43 23 * * *'
+  push:
+    branches: [ "master" ]
+    # Publish semver tags as releases.
+    tags: [ 'v*.*.*' ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@f3c664df7af409cb4873aa5068053ba9d61a57b6 #v2.6.0
+        with:
+          cosign-release: 'v1.13.1'
+
+
+      # Workaround: https://github.com/docker/build-push-action/issues/461
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@79abd3f86f79a9d68a23c75a09a9a85889262adf
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ FROM gcr.io/distroless/python3-debian11:nonroot
 COPY --from=build-venv --chown=nonroot:nonroot /venv /venv
 VOLUME /config
 VOLUME /data
+ENV PATH=/venv/bin:$PATH
 ENV XDG_CONFIG_HOME=/config
 ENV XDG_DATA_HOME=/data
-ENTRYPOINT ["/venv/bin/r2e"]
+ENTRYPOINT ["r2e"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM debian:11-slim AS build-venv
+COPY . /app
+WORKDIR /app
+RUN apt-get update && \
+    apt-get install --no-install-suggests --no-install-recommends --yes python3-venv && \
+    python3 -m venv /venv && \
+    /venv/bin/pip3 install --upgrade pip && \
+    /venv/bin/pip3 install /app
+
+FROM gcr.io/distroless/python3-debian11:nonroot
+COPY --from=build-venv --chown=nonroot:nonroot /venv /venv
+VOLUME /config
+VOLUME /data
+ENV XDG_CONFIG_HOME=/config
+ENV XDG_DATA_HOME=/data
+ENTRYPOINT ["/venv/bin/r2e"]

--- a/README.rst
+++ b/README.rst
@@ -46,11 +46,11 @@ __ `Ubuntu package`_
 Docker
 ------
 
-A docker package exists for this project: 
+A docker package exists for this project::
 
   $ git pull ghcr.io/rss2email/rss2email:master
 
-docker-compose.yaml
+docker-compose.yaml::yaml
 ~~~~~~~~~~~~~~~~~~~
   version: '2'
   services:
@@ -69,7 +69,7 @@ The example docker-compose snippet sets up chadburn (or ofelia) job scheduler to
 
 You need to run `chown 65532:65532 config data` to have the correct ownership of files for this rootless docker image.
 
-To use r2e commands, for listing subscribed feeds for example:
+To use r2e commands, for listing subscribed feeds for example::
 
   docker-compose exec rss2email r2e list
 

--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,15 @@ A docker package exists for this project::
 
   $ git pull ghcr.io/rss2email/rss2email:master
 
-docker-compose.yaml::yaml
-~~~~~~~~~~~~~~~~~~~
+Then it can be used like::
+
+  $ docker run  -v ./data:/data -v ./config:/config rss2email list
+
+Docker compose
+~~~~~~~~~~~~~~
+
+Here is an example docker-compose.yaml::
+
   version: '2'
   services:
     rss2email:
@@ -65,9 +72,11 @@ docker-compose.yaml::yaml
         chadburn.job-exec.rss2email.schedule: "@every 5m"
         chadburn.job-exec.rss2email.command: "r2e run"
 
-The example docker-compose snippet sets up chadburn (or ofelia) job scheduler to run r2e periodically. For the labels to be picked up, it is required that the container keeps running which is ensured with the entrypoint. Python's Event().wait() was used as there is no shell and this method should use less cpu than sleeping or looping (with sleep). You can of course abandon this and just call r2e from any other job scheduler as this entrypoint only circumvents chadburn/ofelia limitations.
+The example docker-compose snippet sets up chadburn (or ofelia) job scheduler to run r2e periodically. 
 
-You need to run `chown 65532:65532 config data` to have the correct ownership of files for this rootless docker image.
+Some background for entrypoint override: For the labels to be picked up, it is required that the container keeps running which is ensured with the entrypoint. Python's Event().wait() was used as there is no shell and this method should use less cpu than sleeping or looping (with sleep). You can of course abandon this and just call r2e from any other job scheduler as this entrypoint only circumvents chadburn/ofelia limitations.
+
+You need to run ``chown 65532:65532 config data`` to have the correct ownership of files for this rootless docker image.
 
 To use r2e commands, for listing subscribed feeds for example::
 

--- a/README.rst
+++ b/README.rst
@@ -43,6 +43,37 @@ __ `OpenBSD package`_
 __ `openSUSE package`_
 __ `Ubuntu package`_
 
+Docker
+------
+
+A docker package exists for this project: 
+
+  $ git pull ghcr.io/rss2email/rss2email:master
+
+docker-compose.yaml
+~~~~~~~~~~~~~~~~~~~
+  version: '2'
+  services:
+    rss2email:
+      image: ghcr.io/rss2email/rss2email:master
+      volumes:
+        - ./config:/config
+        - ./data:/data
+      entrypoint: "/venv/bin/python3 -c 'import threading; threading.Event().wait()'"
+      labels:
+        chadburn.enabled: "true"
+        chadburn.job-exec.rss2email.schedule: "@every 5m"
+        chadburn.job-exec.rss2email.command: "r2e run"
+
+The example docker-compose snippet sets up chadburn (or ofelia) job scheduler to run r2e periodically. For the labels to be picked up, it is required that the container keeps running which is ensured with the entrypoint. Python's Event().wait() was used as there is no shell and this method should use less cpu than sleeping or looping (with sleep). You can of course abandon this and just call r2e from any other job scheduler as this entrypoint only circumvents chadburn/ofelia limitations.
+
+You need to run `chown 65532:65532 config data` to have the correct ownership of files for this rootless docker image.
+
+To use r2e commands, for listing subscribed feeds for example:
+
+  docker-compose exec rss2email r2e list
+
+
 Installing by hand
 ------------------
 


### PR DESCRIPTION
Apparently there was a similar PR/suggestion in the past but it was withdrawn. I am reviving that effort.

I wrote a minimal distroless (there's only python) and rootless Dockerfile. I successfully use this in my more elaborate setup with rssbridge and chadburn scheduling. The docker-compose example in the README.rst is taken from my setup.

This PR contains a github automation for building a docker image for ghcr.io.

I will implement any necessary changes if requested.