### PR TITLE
Support sending mail via LMTP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -205,6 +205,37 @@ your login credentials to the server.
 
 __ `Simple Mail Transport Protocol`_
 
+LMTP
+----
+
+LMTP__ is an alternative to SMTP where the receiving side does not have
+a mail queue and is mainly used to deliver mail when the target mail
+server is located on the same machine as the sending site. If you want
+to use LMTP, edit the configuration file and fill in your mail server's
+details::
+
+  [DEFAULT]
+  ...
+  email-protocol = lmtp
+  lmtp-server = /path/to/lmtp.socket
+  lmtp-auth = False
+  ...
+
+If your server exposes LMTP via a TCP socket, specify the server and
+port via ``lmtp-server`` and ``lmtp-port``::
+
+  lmtp-server = 127.0.0.1
+  lmtp-port = 2003
+
+If your server requires you to login, change ``lmtp-auth = False`` to
+``lmtp-auth = True`` and enter your username and password::
+
+  lmtp-auth = True
+  lmtp-username = username
+  lmtp-password = password
+
+__ `Local Mail Transport Protocol`_
+
 Post-processing
 ---------------
 

--- a/r2e.1
+++ b/r2e.1
@@ -276,6 +276,19 @@ SMTP server
 .IP smtp-ssl
 Connect to the SMTP server using SSL
 .RE
+.SS LMTP configuration
+.IP lmtp-auth
+Set to True to use SMTP AUTH for LMTP
+.IP lmtp-username
+username for SMTP AUTH
+.IP lmtp-password
+password for SMTP AUTH
+.IP lmtp-server
+LMTP server. To specify a Unix socket, you must use an absolute path starting
+with '/'.
+.IP lmtp-port
+LMTP port
+.RE
 .SS IMAP configuration
 .IP imap-auth
 set to True to use IMAP auth.

--- a/rss2email/config.py
+++ b/rss2email/config.py
@@ -225,7 +225,7 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ('body-width', str(0)),
 
         ### Mailing
-        # Select protocol from: sendmail, smtp, imap
+        # Select protocol from: sendmail, smtp, lmtp, imap
         ('email-protocol', 'sendmail'),
         # True: Use SMTP_SERVER to send mail.
         # Sendmail (or compatible) configuration
@@ -238,6 +238,12 @@ CONFIG['DEFAULT'] = _collections.OrderedDict((
         ('smtp-server', 'smtp.example.net'),
         ('smtp-port', '465'),
         ('smtp-ssl', str(False)),       # Connect to the SMTP server using SSL
+        # LMTP configuration
+        ('lmtp-auth', str(False)),      # set to True to use SMTP AUTH for LMTP authentication
+        ('lmtp-username', 'username'),  # username for SMTP AUTH
+        ('lmtp-password', 'password'),  # password for SMTP AUTH
+        ('lmtp-server', '/path/to/lmtp.socket'), # Unix socket or server address
+        ('lmtp-port', '2003'),
         # IMAP configuration
         ('imap-auth', str(False)),      # set to True to use IMAP auth.
         ('imap-username', 'username'),  # username for IMAP authentication

--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -224,6 +224,33 @@ def smtp_send(recipient, message, config=None, section='DEFAULT'):
     smtp.send_message(message, config.get(section, 'from'), recipient.split(','))
     smtp.quit()
 
+def lmtp_send(recipient, message, config=None, section='DEFAULT'):
+    if config is None:
+        config = _config.CONFIG
+    server = config.get(section, 'lmtp-server')
+    port = config.getint(section, 'lmtp-port')
+
+    _LOG.debug('sending message to {} via {}'.format(recipient, server))
+    lmtp_auth = config.getboolean(section, 'lmtp-auth')
+    try:
+        lmtp = _smtplib.LMTP(host=server, port=port)
+    except KeyboardInterrupt:
+        raise
+    except Exception as e:
+        raise _error.SMTPConnectionError(server=server) from e
+    if lmtp_auth:
+        username = config.get(section, 'lmtp-username')
+        password = config.get(section, 'lmtp-password')
+        try:
+            lmtp.login(username, password)
+        except KeyboardInterrupt:
+            raise
+        except Exception as e:
+            raise _error.SMTPAuthenticationError(
+                server=server, username=username)
+    lmtp.send_message(message, config.get(section, 'from'), recipient.split(','))
+    lmtp.quit()
+
 def imap_send(message, config=None, section='DEFAULT'):
     if config is None:
         config = _config.CONFIG
@@ -406,6 +433,10 @@ def send(recipient, message, config=None, section='DEFAULT'):
     protocol = config.get(section, 'email-protocol')
     if protocol == 'smtp':
         smtp_send(
+            recipient=recipient, message=message,
+            config=config, section=section)
+    elif protocol == 'lmtp':
+        lmtp_send(
             recipient=recipient, message=message,
             config=config, section=section)
     elif protocol == 'imap':


### PR DESCRIPTION
When rss2email runs on the same host as the target mail server, then it is quite common that the server exposes a locally accessible LMTP socket. The LMTP protocol is quite similar to the SMTP protocol, but generally has no mail queue and thus requires no MDA. Instead, the mail is directly porcessed by the mail server without any intermediates.

Implement LMTP support such that it becomes possible to deliver mail to such servers directly.