### PR TITLE
Fix UserWarning in prettify.py

### DIFF
--- a/rss2email/post_process/prettify.py
+++ b/rss2email/post_process/prettify.py
@@ -82,7 +82,7 @@ def pretty(feed, parsed, entry, guid, message):
     content = str(message.get_payload(decode=True), encoding)
 
     # modify content
-    soup = BeautifulSoup(content)
+    soup = BeautifulSoup(content, "lxml")
     content = soup.prettify()
 
     # BeautifulSoup uses unicode, so we perhaps have to adjust the encoding.


### PR DESCRIPTION
When using the prettify post-processor, this is emitted:

...rss2email-3.14-py3.6.egg/rss2email/post_process/prettify.py:85: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("lxml"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

The code that caused this warning is on line 85 of the file ...rss2email-3.14-py3.6.egg/rss2email/post_process/prettify.py. To get rid of this warning, pass the additional argument 'features="lxml"' to the BeautifulSoup constructor.