### PR TITLE
support oauth2 login

### DIFF
--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 #
-# Copyright (C) 2012-2022 Amir Yalon <git@please.nospammail.net>
+# Copyright (C) 2012-2024 Amir Yalon <git@please.nospammail.net>
 #                         Arun Persaud <apersaud@lbl.gov>
 #                         Dmitry Bogatov <KAction@gnu.org>
 #                         George Saunders <georgesaunders@gmail.com>
@@ -254,18 +254,33 @@ def lmtp_send(recipient, message, config=None, section='DEFAULT'):
 def imap_send(message, config=None, section='DEFAULT'):
     if config is None:
         config = _config.CONFIG
-    server = config.get(section, 'imap-server')
-    port = config.getint(section, 'imap-port')
-    _LOG.debug('sending message to {}:{}'.format(server, port))
-    ssl = config.getboolean(section, 'imap-ssl')
-    if ssl:
+    server = config.get(section, "imap-server")
+    port = config.getint(section, "imap-port")
+    _LOG.debug("sending message to {}:{}".format(server, port))
+    ssl = config.getboolean(section, "imap-ssl")
+    oauth2 = config.getboolean(section, "imap-oauth2")
+    if oauth2:
+        imap = _imaplib.IMAP4_SSL(server, ssl_context=_ssl.create_default_context())
+    elif ssl:
         imap = _imaplib.IMAP4_SSL(server, port)
     else:
         imap = _imaplib.IMAP4(server, port)
     try:
-        if config.getboolean(section, 'imap-auth'):
-            username = config.get(section, 'imap-username')
-            password = config.get(section, 'imap-password')
+        if oauth2:
+            username = config.get(section, "imap-username")
+            client_id = config.get(section, "imap-clientid")
+            client_secret = config.get(section, "imap-clientsecret")
+            refresh_token = config.get(section, "imap-refreshtoken")
+            auth_string = _oauth2.get_oauth2_auth_string(
+                client_id,
+                client_secret,
+                refresh_token,
+                username,
+            )
+            imap.authenticate("XOAUTH2", lambda x: auth_string)
+        elif config.getboolean(section, "imap-auth"):
+            username = config.get(section, "imap-username")
+            password = config.get(section, "imap-password")
             try:
                 if not ssl:
                     imap.starttls()

--- a/rss2email/oauth2.py
+++ b/rss2email/oauth2.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2024 Arun Persaud <apersaud@lbl.gov>
+#
+# This file is part of rss2email.
+#
+# rss2email is free software: you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 2 of the License, or (at your option) version 3 of
+# the License.
+#
+# rss2email is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# rss2email.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Enable OAuth2 for gmail.
+
+Most likely this can also work for other oauth2 providers with minor modifications.
+
+The file provides two functions:
+* get_oauth2_auth_string: this is used in email.py to log into gmail using oauth2
+* get_refresh_token: get a refresh token only needs to be called once.
+"""
+
+import json
+from pathlib import Path
+import sys
+import urllib.parse
+import urllib.request
+
+
+def get_oauth2_auth_string(
+    client_id: str,
+    client_secret: str,
+    refresh_token: str,
+    username: str,
+    request_url: str = "https://accounts.google.com",
+) -> str:
+    """Create a string with an oauth2 access token.
+
+    This make a request to the oauth2 provider to get an access token
+    and then formats this correctly to be used to authenticate an IMAP instance.
+    """
+
+    parameters = {}
+    parameters["client_id"] = client_id
+    parameters["client_secret"] = client_secret
+    parameters["refresh_token"] = refresh_token
+    parameters["grant_type"] = "refresh_token"
+
+    response = urllib.request.urlopen(
+        f"{request_url}/o/oauth2/token",
+        urllib.parse.urlencode(parameters).encode("utf-8"),
+    ).read()
+    response = json.loads(response)
+
+    access_token = response["access_token"]
+
+    auth_string = f"user={username}\1auth=Bearer {access_token}\1\1"
+
+    return auth_string
+
+
+def get_refresh_token(
+    client_id: str,
+    client_secret: str,
+    request_url: str = "https://accounts.google.com",
+    scope: str = "https://mail.google.com/",
+) -> None:
+    """Create a reusable oauth2 refresh token.
+
+    Makes two requests to the oauth2 provider to generate a refresh token.
+
+    Refresh tokens are then used to generate authorization tockens for
+    every login attempt.
+
+    """
+    parameters = {}
+    parameters["client_id"] = client_id
+    parameters["redirect_uri"] = "http://localhost_error/"
+    parameters["prompt"] = "consent"
+    parameters["scope"] = scope
+    parameters["access_type"] = "offline"
+    parameters["response_type"] = "code"
+
+    parameter_list = []
+    for param in sorted(parameters.items(), key=lambda x: x[0]):
+        escaped_param = urllib.parse.quote(param[1], safe="~-._")
+        parameter_list.append(f"{param[0]}={escaped_param}")
+    parameter_str = "&".join(parameter_list)
+
+    authorize_url = f"{request_url}/o/oauth2/auth?{parameter_str}"
+
+    print("To get a refresh token, follow this link:")
+    print(f"  {authorize_url}")
+    print(
+        "Once you allowed access to your email via oauth2, you will be redirected to a new webpage. The redirect will not work!"
+    )
+    print(
+        "However, the url will include the needed verification code for the next step.\n"
+        "Copy the whole URL out of the browser and paste below"
+    )
+    tmp = input("Enter failed URL: ")
+
+    # add error checking
+    tmp = tmp.split("code=")[1]
+    authorization_code = tmp.split("&scope")[0]
+
+    parameters = {}
+    parameters["client_id"] = client_id
+    parameters["client_secret"] = client_secret
+    parameters["code"] = authorization_code
+    parameters["redirect_uri"] = "http://localhost/"
+    parameters["grant_type"] = "authorization_code"
+
+    response = urllib.request.urlopen(
+        f"{request_url}/o/oauth2/token",
+        urllib.parse.urlencode(parameters).encode("utf-8"),
+    ).read()
+
+    response = json.loads(response)
+    print(f"Refresh Token: {response['refresh_token']}")


### PR DESCRIPTION
Initial support for oauth2 login (at least for gmail).
The user needs to set 4 variables in the config file:

imap-oauth2 is a boolean that needs to be set to True. 
imap-clientid, imap-clientsecret, imap-refreshtoken are needed to log in.

The new file oauth2.py also includes code to generate a refresh token. Currently the function needs to be called manually though and this should probably be integrated into r2e before merging.

I wanted to create this PR to start a discussion on what else needs to change so that this can be integrated in the future.

I'm running a similar code (but currently not the same) on my desktop where this is working already.

Looking forward to hearing back from you. 