### PR TITLE
Wrap lines to adhere to RFC5321

### DIFF
--- a/rss2email/email.py
+++ b/rss2email/email.py
@@ -182,6 +182,16 @@ def get_message(sender, recipient, subject, body, content_type,
                 html=body)
     return message
 
+def wrap_lines(content, max_length=998):
+    """Wrap lines to ensure no line exceeds max_length characters."""
+    wrapped_lines = []
+    for line in content.splitlines():
+        while len(line) > max_length:
+            wrapped_lines.append(line[:max_length])
+            line = line[max_length:]
+        wrapped_lines.append(line)
+    return '\r\n'.join(wrapped_lines)
+
 def smtp_send(recipient, message, config=None, section='DEFAULT'):
     if config is None:
         config = _config.CONFIG
@@ -221,7 +231,10 @@ def smtp_send(recipient, message, config=None, section='DEFAULT'):
         except Exception as e:
             raise _error.SMTPAuthenticationError(
                 server=server, username=username)
-    smtp.send_message(message, config.get(section, 'from'), recipient.split(','))
+    message_str = message.as_string()
+    wrapped_message_str = wrap_lines(message_str)
+    wrapped_message = _email.message_from_string(wrapped_message_str)
+    smtp.send_message(wrapped_message, config.get(section, 'from'), recipient.split(','))
     smtp.quit()
 
 def lmtp_send(recipient, message, config=None, section='DEFAULT'):


### PR DESCRIPTION
This is to avoid this error:

Traceback (most recent call last):
File "/usr/local/bin/r2e", line 8, in
sys.exit(run())
^^^^^
File "/usr/local/lib/python3.12/site-packages/rss2email/main.py", line 204, in run
args.func(feeds=feeds, args=args)
File "/usr/local/lib/python3.12/site-packages/rss2email/command.py", line 97, in run
feed.run(send=args.send, clean=args.clean)
File "/usr/local/lib/python3.12/site-packages/rss2email/feed.py", line 969, in run
self._send(sender=sender, message=message)
File "/usr/local/lib/python3.12/site-packages/rss2email/feed.py", line 918, in _send
_email.send(recipient=self.to, message=message,
File "/usr/local/lib/python3.12/site-packages/rss2email/email.py", line 435, in send
smtp_send(
File "/usr/local/lib/python3.12/site-packages/rss2email/email.py", line 224, in smtp_send
smtp.send_message(message, config.get(section, 'from'), recipient.split(','))
File "/usr/local/lib/python3.12/smtplib.py", line 975, in send_message
return self.sendmail(from_addr, to_addrs, flatmsg, mail_options,
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.12/smtplib.py", line 897, in sendmail
raise SMTPDataError(code, resp)
smtplib.SMTPDataError: (500, b'Line too long (see RFC5321 4.5.3.1.6)')