### PR TITLE
Add basic support for adding categories to feeds

### DIFF
--- a/rss2email/feed.py
+++ b/rss2email/feed.py
@@ -178,6 +178,7 @@ class Feed (object):
     # attributes that aren't in DEFAULT
     _non_default_configured_attributes = [
         'url',
+        'category',
         ]
     # attributes that are in DEFAULT
     _default_configured_attributes = [
@@ -537,6 +538,8 @@ class Feed (object):
                 ('X-RSS-URL', self._get_entry_link(entry)),
                 ('X-RSS-TAGS', self._get_entry_tags(entry)),
                 ))
+        if self.category:
+            extra_headers['X-RSS-Category'] = self.category
         # remove empty tags, etc.
         keys = {k for k, v in extra_headers.items() if v is None}
         for key in keys:


### PR DESCRIPTION
This changes adds support for defining a category for each feed, which is added to message headers as X-RSS-Category.  The intent is to allow this to be read by software like procmail to sort feeds into different mail folders based on content.

For example, set Games as the category for all gaming-related feeds to, and procmail can use that header to automatically deliver all items from those fields to a Games folder.  This provides a way to have related content be sorted into into different folders on your mail server automatically.

The current implementation is very basic, as noted.  It lets you define a category for each feed.  E.g.:

```
[feed.Legroom.net]
url = https://www.legroom.net/rss.xml
category = Games
```

If category is set, it's added as X-RSS-Category.  If not set, nothing changes from default behavior.

I don't know if this is the "right" way to add this, but it's easy and stays out of the way unless someone specifically wants it.  I welcome feedback for improvements, though.

Some additional background:  I wrote my own RSS to e-mail program in PHP long ago, but am tired of maintaining it.  This looks like near perfect replacement, but being able to set categories and group feed content is a really convenient feature that I miss.  Hope to find a way to get this merged upstream.